### PR TITLE
feat(oss): add support for read only accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2544,6 +2544,7 @@ dependencies = [
  "transform",
  "uaparser",
  "url",
+ "urlencoding",
  "utoipa",
 ]
 

--- a/src/api/common/src/auth/validator.rs
+++ b/src/api/common/src/auth/validator.rs
@@ -38,7 +38,7 @@ use openobserve_core::{
 use crate::common::{
     infra::config::ORG_INGESTION_TOKENS,
     meta::{
-        ingestion_routes,
+        ingestion_routes, read_only_routes,
         user::{
             AuthTokensExt, TokenValidationResponse, TokenValidationResponseBuilder,
             get_default_user_role,
@@ -118,6 +118,33 @@ pub struct AuthValidationResult {
     pub user_email: String,
     pub user_role: Option<UserRole>,
     pub is_internal_user: bool,
+}
+
+/// What a read-only account is told when it attempts a write.
+const READ_ONLY_DENIED: &str = "Read only account: this operation is not permitted";
+
+/// Should this authenticated request be refused because the account is read
+/// only?
+///
+/// Enterprise builds answer this with the OpenFGA model — every route carries a
+/// declared permission — so the helper is a no-op there. OSS builds have no
+/// authorization model behind the roles, so a `Viewer` (or the system-managed
+/// `SreAgent`) is held to the read-only route policy instead: safe methods, the
+/// declared query-by-POST routes, and self-service maintenance of its own
+/// account. Everything else, ingestion included, is refused.
+///
+/// This is checked on every authenticated request — password, session and
+/// static-token alike — rather than in the permission layer, because in OSS the
+/// `AuthExtractor` marks every request `bypass_check`, so the permission layer
+/// never runs.
+#[cfg(not(feature = "enterprise"))]
+fn read_only_denied(user: &User, method: &Method, path: &str) -> bool {
+    user.role.is_read_only() && !read_only_routes::is_request_allowed(method, path, &user.email)
+}
+
+#[cfg(feature = "enterprise")]
+fn read_only_denied(_user: &User, _method: &Method, _path: &str) -> bool {
+    false
 }
 
 /// Helper function to build a successful token validation response
@@ -523,6 +550,10 @@ pub async fn validate_credentials(
             });
         }
 
+        if read_only_denied(&user, method, path) {
+            return Err(AuthError::Forbidden(READ_ONLY_DENIED.to_string()));
+        }
+
         return Ok(build_token_validation_response(&user));
     }
 
@@ -550,6 +581,11 @@ pub async fn validate_credentials(
     // longer accepts a user's ingestion token). Service-account tokens, which
     // are valid across the API, are handled earlier and are unaffected.
     if is_ingestion_path && user.token.eq(&user_password) {
+        // A read-only account has no write path at all, so its token cannot
+        // ingest either.
+        if read_only_denied(&user, method, path) {
+            return Err(AuthError::Forbidden(READ_ONLY_DENIED.to_string()));
+        }
         return Ok(build_token_validation_response(&user));
     }
 
@@ -582,12 +618,9 @@ pub async fn validate_credentials(
         }
     }
     let in_pass = get_hash(user_password, &user.salt);
-    if !user.password.eq(&in_pass)
-        && !user
-            .password_ext
-            .unwrap_or("".to_string())
-            .eq(&user_password)
-    {
+    // `as_deref` rather than `unwrap()`: `user` is still needed below for the
+    // read-only check and the response, so the password must not be moved out.
+    if !user.password.eq(&in_pass) && user.password_ext.as_deref().unwrap_or("") != user_password {
         return Ok(TokenValidationResponse {
             is_valid: false,
             user_email: "".to_string(),
@@ -598,6 +631,15 @@ pub async fn validate_credentials(
             given_name: "".to_string(),
         });
     }
+
+    // Credentials are good — now decide whether this account may do this. The
+    // check sits after authentication on purpose: answering "403 read only"
+    // before the password is verified would tell an anonymous caller that the
+    // account exists and what role it holds.
+    if read_only_denied(&user, method, path) {
+        return Err(AuthError::Forbidden(READ_ONLY_DENIED.to_string()));
+    }
+
     if !path.contains("/user")
         || (path.contains("/user")
             && (user.role.eq(&UserRole::Admin)
@@ -1067,6 +1109,19 @@ pub async fn validator_rum(req_data: &RequestData) -> Result<AuthValidationResul
                         );
                         return Err(AuthError::Unauthorized("Unauthorized Access".to_string()));
                     }
+
+                    // Every RUM route is an ingest, and the rum_token is a
+                    // separate credential that never passes through
+                    // `validate_credentials` — so the read-only check has to be
+                    // repeated here rather than inherited.
+                    if read_only_denied(&user, &req_data.method, req_data.uri.path()) {
+                        log::warn!(
+                            "Read only account attempted RUM ingest access: {}",
+                            user.email
+                        );
+                        return Err(AuthError::Forbidden(READ_ONLY_DENIED.to_string()));
+                    }
+
                     Ok(AuthValidationResult {
                         user_email: user.email,
                         user_role: Some(user.role),
@@ -1270,6 +1325,76 @@ mod tests {
         infra::config::{ORG_USERS, USERS},
         meta::user::UserRequest,
     };
+
+    #[cfg(not(feature = "enterprise"))]
+    fn user_with_role(role: UserRole) -> User {
+        User {
+            email: "viewer@example.com".to_string(),
+            first_name: "Read".to_string(),
+            last_name: "Only".to_string(),
+            password: "hash".to_string(),
+            salt: "salt".to_string(),
+            token: "tok".to_string(),
+            rum_token: None,
+            role,
+            org: "default".to_string(),
+            is_external: false,
+            password_ext: None,
+        }
+    }
+
+    /// The OSS gate: a read-only account may read and run searches, may
+    /// maintain its own account, and may do nothing else — ingestion included.
+    #[cfg(not(feature = "enterprise"))]
+    #[test]
+    fn read_only_accounts_may_only_read() {
+        let viewer = user_with_role(UserRole::Viewer);
+
+        assert!(!read_only_denied(
+            &viewer,
+            &Method::GET,
+            "default/dashboards"
+        ));
+        assert!(!read_only_denied(&viewer, &Method::POST, "default/_search"));
+        assert!(!read_only_denied(
+            &viewer,
+            &Method::PUT,
+            "default/users/viewer@example.com"
+        ));
+
+        assert!(read_only_denied(
+            &viewer,
+            &Method::POST,
+            "default/dashboards"
+        ));
+        assert!(read_only_denied(&viewer, &Method::POST, "default/_bulk"));
+        assert!(read_only_denied(
+            &viewer,
+            &Method::PUT,
+            "default/users/someone.else@example.com"
+        ));
+    }
+
+    /// Roles that are not read-only are never touched by the gate, whatever the
+    /// request looks like.
+    #[cfg(not(feature = "enterprise"))]
+    #[test]
+    fn writable_roles_are_never_denied_by_the_read_only_gate() {
+        for role in [
+            UserRole::Root,
+            UserRole::Admin,
+            UserRole::Editor,
+            UserRole::ServiceAccount,
+        ] {
+            let user = user_with_role(role);
+            assert!(!read_only_denied(
+                &user,
+                &Method::POST,
+                "default/dashboards"
+            ));
+            assert!(!read_only_denied(&user, &Method::POST, "default/_bulk"));
+        }
+    }
 
     #[test]
     fn extract_rum_token_prefers_query_over_header() {

--- a/src/api/common/src/auth/validator.rs
+++ b/src/api/common/src/auth/validator.rs
@@ -120,20 +120,9 @@ pub struct AuthValidationResult {
     pub is_internal_user: bool,
 }
 
-/// Refuse this request if the authenticated account is read only and the route
-/// is not one it may reach.
-///
-/// Enterprise builds answer this with the OpenFGA model — every route carries a
-/// declared permission — so the check is a no-op there. OSS builds have no
-/// authorization model behind the roles, so a `Viewer` (or the system-managed
-/// `SreAgent`) is held to the read-only route policy instead: safe methods, the
-/// declared query-by-POST routes, and self-service maintenance of its own
-/// account. Everything else, ingestion included, is refused.
-///
-/// Applied to every authenticated request — password, session and static-token
-/// alike — rather than in the permission layer, because in OSS the
-/// `AuthExtractor` marks every request `bypass_check`, so the permission layer
-/// never runs.
+/// Refuse this request if the account is read only and the route is not one it
+/// may reach. OSS only: enterprise answers this with OpenFGA. Applied here
+/// rather than in the permission layer, which OSS skips via `bypass_check`.
 #[cfg(not(feature = "enterprise"))]
 fn check_read_only(
     role: &UserRole,
@@ -292,12 +281,8 @@ pub async fn validate_credentials(
     let resp =
         validate_credentials_inner(user_id, user_password, path, method, from_session).await?;
 
-    // One gate covering every credential branch below. `validate_credentials_inner`
-    // has several successful exits — service-account token, user ingestion token,
-    // password — and is under active security churn; checking the resolved
-    // response instead of each exit means a branch added later cannot silently
-    // hand a read-only account a write path. Responses that failed to
-    // authenticate carry no role and are left alone.
+    // Gate the resolved response, not each of the inner fn's several success
+    // exits, so a branch added later cannot slip past this.
     if let Some(role) = resp.user_role.as_ref() {
         check_read_only(role, &resp.user_email, method, path)?;
     }
@@ -645,8 +630,7 @@ async fn validate_credentials_inner(
         }
     }
     let in_pass = get_hash(user_password, &user.salt);
-    // `as_deref` rather than `unwrap()`: `user` is still needed below for the
-    // read-only check and the response, so the password must not be moved out.
+    // `as_deref`, not `unwrap()`: `user` is still needed below.
     if !user.password.eq(&in_pass) && user.password_ext.as_deref().unwrap_or("") != user_password {
         return Ok(TokenValidationResponse {
             is_valid: false,
@@ -1129,12 +1113,8 @@ pub async fn validator_rum(req_data: &RequestData) -> Result<AuthValidationResul
                         return Err(AuthError::Unauthorized("Unauthorized Access".to_string()));
                     }
 
-                    // The rum_token is a separate credential that never passes
-                    // through `validate_credentials`, so the read-only check has
-                    // to be repeated here rather than inherited. Every RUM route
-                    // is an ingest, so the role alone decides — consulting the
-                    // route table would be misleading, as no RUM path can ever
-                    // appear in it.
+                    // rum_token bypasses `validate_credentials`, so repeat the
+                    // check here. Every RUM route is an ingest, so role decides.
                     #[cfg(not(feature = "enterprise"))]
                     if user.role.is_read_only() {
                         log::warn!(
@@ -1367,10 +1347,8 @@ mod tests {
         }
     }
 
-    /// The OSS gate refuses a read-only account a write and allows it a read.
-    /// The route table itself is exercised in `common::meta::read_only_routes`;
-    /// what this asserts is the role conjunction and that the caller's own
-    /// email reaches the self-service rows.
+    /// The table itself is tested in `common::meta::read_only_routes`; this
+    /// covers the role conjunction and the self-service rows.
     #[cfg(not(feature = "enterprise"))]
     #[test]
     fn read_only_accounts_may_only_read() {
@@ -1387,8 +1365,7 @@ mod tests {
         ));
     }
 
-    /// Roles that are not read-only are never touched by the gate, whatever the
-    /// request looks like.
+    /// Writable roles are never touched by the gate.
     #[cfg(not(feature = "enterprise"))]
     #[test]
     fn writable_roles_are_never_denied_by_the_read_only_gate() {

--- a/src/api/common/src/auth/validator.rs
+++ b/src/api/common/src/auth/validator.rs
@@ -120,31 +120,44 @@ pub struct AuthValidationResult {
     pub is_internal_user: bool,
 }
 
-/// What a read-only account is told when it attempts a write.
-const READ_ONLY_DENIED: &str = "Read only account: this operation is not permitted";
-
-/// Should this authenticated request be refused because the account is read
-/// only?
+/// Refuse this request if the authenticated account is read only and the route
+/// is not one it may reach.
 ///
 /// Enterprise builds answer this with the OpenFGA model — every route carries a
-/// declared permission — so the helper is a no-op there. OSS builds have no
+/// declared permission — so the check is a no-op there. OSS builds have no
 /// authorization model behind the roles, so a `Viewer` (or the system-managed
 /// `SreAgent`) is held to the read-only route policy instead: safe methods, the
 /// declared query-by-POST routes, and self-service maintenance of its own
 /// account. Everything else, ingestion included, is refused.
 ///
-/// This is checked on every authenticated request — password, session and
-/// static-token alike — rather than in the permission layer, because in OSS the
+/// Applied to every authenticated request — password, session and static-token
+/// alike — rather than in the permission layer, because in OSS the
 /// `AuthExtractor` marks every request `bypass_check`, so the permission layer
 /// never runs.
 #[cfg(not(feature = "enterprise"))]
-fn read_only_denied(user: &User, method: &Method, path: &str) -> bool {
-    user.role.is_read_only() && !read_only_routes::is_request_allowed(method, path, &user.email)
+fn check_read_only(
+    role: &UserRole,
+    email: &str,
+    method: &Method,
+    path: &str,
+) -> Result<(), AuthError> {
+    if role.is_read_only() && !read_only_routes::is_request_allowed(method, path, email) {
+        log::warn!("Read only account {email} denied {method} {path}");
+        return Err(AuthError::Forbidden(
+            read_only_routes::READ_ONLY_DENIED.to_string(),
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(feature = "enterprise")]
-fn read_only_denied(_user: &User, _method: &Method, _path: &str) -> bool {
-    false
+fn check_read_only(
+    _role: &UserRole,
+    _email: &str,
+    _method: &Method,
+    _path: &str,
+) -> Result<(), AuthError> {
+    Ok(())
 }
 
 /// Helper function to build a successful token validation response
@@ -270,6 +283,29 @@ async fn blocked_external(user: &config::meta::user::User) -> bool {
 }
 
 pub async fn validate_credentials(
+    user_id: &str,
+    user_password: &str,
+    path: &str,
+    method: &Method,
+    from_session: bool,
+) -> Result<TokenValidationResponse, AuthError> {
+    let resp =
+        validate_credentials_inner(user_id, user_password, path, method, from_session).await?;
+
+    // One gate covering every credential branch below. `validate_credentials_inner`
+    // has several successful exits — service-account token, user ingestion token,
+    // password — and is under active security churn; checking the resolved
+    // response instead of each exit means a branch added later cannot silently
+    // hand a read-only account a write path. Responses that failed to
+    // authenticate carry no role and are left alone.
+    if let Some(role) = resp.user_role.as_ref() {
+        check_read_only(role, &resp.user_email, method, path)?;
+    }
+
+    Ok(resp)
+}
+
+async fn validate_credentials_inner(
     user_id: &str,
     user_password: &str,
     path: &str,
@@ -550,10 +586,6 @@ pub async fn validate_credentials(
             });
         }
 
-        if read_only_denied(&user, method, path) {
-            return Err(AuthError::Forbidden(READ_ONLY_DENIED.to_string()));
-        }
-
         return Ok(build_token_validation_response(&user));
     }
 
@@ -581,11 +613,6 @@ pub async fn validate_credentials(
     // longer accepts a user's ingestion token). Service-account tokens, which
     // are valid across the API, are handled earlier and are unaffected.
     if is_ingestion_path && user.token.eq(&user_password) {
-        // A read-only account has no write path at all, so its token cannot
-        // ingest either.
-        if read_only_denied(&user, method, path) {
-            return Err(AuthError::Forbidden(READ_ONLY_DENIED.to_string()));
-        }
         return Ok(build_token_validation_response(&user));
     }
 
@@ -630,14 +657,6 @@ pub async fn validate_credentials(
             family_name: "".to_string(),
             given_name: "".to_string(),
         });
-    }
-
-    // Credentials are good — now decide whether this account may do this. The
-    // check sits after authentication on purpose: answering "403 read only"
-    // before the password is verified would tell an anonymous caller that the
-    // account exists and what role it holds.
-    if read_only_denied(&user, method, path) {
-        return Err(AuthError::Forbidden(READ_ONLY_DENIED.to_string()));
     }
 
     if !path.contains("/user")
@@ -1110,16 +1129,21 @@ pub async fn validator_rum(req_data: &RequestData) -> Result<AuthValidationResul
                         return Err(AuthError::Unauthorized("Unauthorized Access".to_string()));
                     }
 
-                    // Every RUM route is an ingest, and the rum_token is a
-                    // separate credential that never passes through
-                    // `validate_credentials` — so the read-only check has to be
-                    // repeated here rather than inherited.
-                    if read_only_denied(&user, &req_data.method, req_data.uri.path()) {
+                    // The rum_token is a separate credential that never passes
+                    // through `validate_credentials`, so the read-only check has
+                    // to be repeated here rather than inherited. Every RUM route
+                    // is an ingest, so the role alone decides — consulting the
+                    // route table would be misleading, as no RUM path can ever
+                    // appear in it.
+                    #[cfg(not(feature = "enterprise"))]
+                    if user.role.is_read_only() {
                         log::warn!(
                             "Read only account attempted RUM ingest access: {}",
                             user.email
                         );
-                        return Err(AuthError::Forbidden(READ_ONLY_DENIED.to_string()));
+                        return Err(AuthError::Forbidden(
+                            read_only_routes::READ_ONLY_DENIED.to_string(),
+                        ));
                     }
 
                     Ok(AuthValidationResult {
@@ -1343,33 +1367,21 @@ mod tests {
         }
     }
 
-    /// The OSS gate: a read-only account may read and run searches, may
-    /// maintain its own account, and may do nothing else — ingestion included.
+    /// The OSS gate refuses a read-only account a write and allows it a read.
+    /// The route table itself is exercised in `common::meta::read_only_routes`;
+    /// what this asserts is the role conjunction and that the caller's own
+    /// email reaches the self-service rows.
     #[cfg(not(feature = "enterprise"))]
     #[test]
     fn read_only_accounts_may_only_read() {
         let viewer = user_with_role(UserRole::Viewer);
+        let allowed =
+            |method, path| check_read_only(&viewer.role, &viewer.email, method, path).is_ok();
 
-        assert!(!read_only_denied(
-            &viewer,
-            &Method::GET,
-            "default/dashboards"
-        ));
-        assert!(!read_only_denied(&viewer, &Method::POST, "default/_search"));
-        assert!(!read_only_denied(
-            &viewer,
-            &Method::PUT,
-            "default/users/viewer@example.com"
-        ));
-
-        assert!(read_only_denied(
-            &viewer,
-            &Method::POST,
-            "default/dashboards"
-        ));
-        assert!(read_only_denied(&viewer, &Method::POST, "default/_bulk"));
-        assert!(read_only_denied(
-            &viewer,
+        assert!(allowed(&Method::POST, "default/_search"));
+        assert!(!allowed(&Method::POST, "default/dashboards"));
+        assert!(allowed(&Method::PUT, "default/users/viewer@example.com"));
+        assert!(!allowed(
             &Method::PUT,
             "default/users/someone.else@example.com"
         ));
@@ -1387,12 +1399,9 @@ mod tests {
             UserRole::ServiceAccount,
         ] {
             let user = user_with_role(role);
-            assert!(!read_only_denied(
-                &user,
-                &Method::POST,
-                "default/dashboards"
-            ));
-            assert!(!read_only_denied(&user, &Method::POST, "default/_bulk"));
+            assert!(
+                check_read_only(&user.role, &user.email, &Method::POST, "default/_bulk").is_ok()
+            );
         }
     }
 

--- a/src/api/grpc/src/handler/grpc/auth/mod.rs
+++ b/src/api/grpc/src/handler/grpc/auth/mod.rs
@@ -25,12 +25,8 @@ pub fn check_auth(req: Request<()>) -> Result<Request<()>, Status> {
     check_auth_inner(req, false, false)
 }
 
-/// Authenticate a gRPC service that writes data, on the internal cluster
-/// credential set.
-///
-/// Same as [`check_auth`], but marked as a write so a read-only account cannot
-/// reach it. Kept separate from [`check_otlp_auth`] because these services do
-/// *not* accept org ingestion tokens.
+/// Like [`check_auth`] but marked as a write, so read-only accounts are refused.
+/// Separate from [`check_otlp_auth`]: these services take no org ingestion token.
 pub fn check_write_auth(req: Request<()>) -> Result<Request<()>, Status> {
     check_auth_inner(req, false, true)
 }
@@ -49,7 +45,6 @@ fn check_auth_inner(
     allow_org_ingestion_token: bool,
     is_write: bool,
 ) -> Result<Request<()>, Status> {
-    // Only the OSS read-only gate consults this; enterprise defers to OpenFGA.
     #[cfg(feature = "enterprise")]
     let _ = is_write;
 
@@ -123,11 +118,8 @@ fn check_auth_inner(
             return Err(Status::unauthenticated("No valid auth token[4]"));
         };
 
-        // Authenticate first. The read-only check below is an *authorization*
-        // decision and must not run against an unverified caller: doing so
-        // answers `permission_denied` rather than `unauthenticated` to anyone
-        // who merely guesses a read-only account's email, confirming both that
-        // the account exists and that it is read only.
+        // Authenticate before the authorization check below, so an unverified
+        // caller gets `unauthenticated` rather than `permission_denied`.
         let authenticated = user.token.eq(&credentials.password) || {
             let in_pass = get_hash(&credentials.password, &user.salt);
             user_id.eq(&user.email)
@@ -137,11 +129,8 @@ fn check_auth_inner(
             return Err(Status::unauthenticated("No valid auth token[5]"));
         }
 
-        // A read-only account has no write path over HTTP, so it must not gain
-        // one over gRPC either. Keyed on the service's declared `is_write`
-        // rather than on `allow_org_ingestion_token`, which only marks the OTLP
-        // services and would leave the internal ingest service uncovered.
-        // Enterprise defers to OpenFGA, exactly as the HTTP gate does.
+        // Keyed on `is_write`, not `allow_org_ingestion_token` — the latter
+        // marks only OTLP and would leave the internal ingest service uncovered.
         #[cfg(not(feature = "enterprise"))]
         if is_write && user.role.is_read_only() {
             log::warn!("Read only account {user_id} denied gRPC write");
@@ -168,8 +157,7 @@ mod tests {
 
     use super::*;
 
-    /// Registers a read-only Viewer in `default` and returns a request bearing
-    /// `authorization`/`organization` metadata for the given Basic credential.
+    /// Registers a Viewer in `default` and builds a request with that credential.
     #[cfg(not(feature = "enterprise"))]
     fn viewer_request(basic: &str) -> tonic::Request<()> {
         cache_instance_id("instance");
@@ -208,8 +196,7 @@ mod tests {
         request
     }
 
-    /// A read-only account is refused on a write service but still reaches the
-    /// read services, which is the whole point of the role.
+    /// Refused on write services, still allowed on read services.
     #[cfg(not(feature = "enterprise"))]
     #[tokio::test]
     async fn test_read_only_account_denied_on_write_service() {
@@ -221,10 +208,8 @@ mod tests {
         assert!(check_auth(viewer_request(basic)).is_ok());
     }
 
-    /// Authorization must not be decided before authentication: a wrong password
-    /// on a write service has to read as `unauthenticated`, never
-    /// `permission_denied` — the latter would confirm to an unauthenticated
-    /// caller that the account exists and is read only.
+    /// A wrong password must read as `unauthenticated`, not `permission_denied`,
+    /// which would confirm the account exists and is read only.
     #[cfg(not(feature = "enterprise"))]
     #[tokio::test]
     async fn test_bad_password_is_unauthenticated_not_permission_denied() {

--- a/src/api/grpc/src/handler/grpc/auth/mod.rs
+++ b/src/api/grpc/src/handler/grpc/auth/mod.rs
@@ -108,6 +108,17 @@ fn check_auth_inner(
             return Err(Status::unauthenticated("No valid auth token[4]"));
         };
 
+        // `allow_org_ingestion_token` marks the OTLP logs/metrics/traces
+        // services — i.e. this request is an ingest. A read-only account has no
+        // write path over HTTP, so it must not gain one over gRPC either.
+        // Enterprise builds also run their own RBAC on top of this.
+        if allow_org_ingestion_token && user.role.is_read_only() {
+            log::warn!("Read only account attempted OTLP gRPC ingestion: {user_id}");
+            return Err(Status::permission_denied(
+                "Read only account: this operation is not permitted",
+            ));
+        }
+
         if user.token.eq(&credentials.password) {
             let mut req = req;
             let user_id_metadata = MetadataValue::try_from(&user_id).unwrap();

--- a/src/api/grpc/src/handler/grpc/auth/mod.rs
+++ b/src/api/grpc/src/handler/grpc/auth/mod.rs
@@ -22,7 +22,17 @@ use openobserve_core::auth::get_hash;
 use tonic::{Request, Status, metadata::MetadataValue};
 
 pub fn check_auth(req: Request<()>) -> Result<Request<()>, Status> {
-    check_auth_inner(req, false)
+    check_auth_inner(req, false, false)
+}
+
+/// Authenticate a gRPC service that writes data, on the internal cluster
+/// credential set.
+///
+/// Same as [`check_auth`], but marked as a write so a read-only account cannot
+/// reach it. Kept separate from [`check_otlp_auth`] because these services do
+/// *not* accept org ingestion tokens.
+pub fn check_write_auth(req: Request<()>) -> Result<Request<()>, Status> {
+    check_auth_inner(req, false, true)
 }
 
 /// Authenticate external OTLP ingestion requests.
@@ -31,12 +41,13 @@ pub fn check_auth(req: Request<()>) -> Result<Request<()>, Status> {
 /// logs, metrics, and traces services. Internal cluster RPCs continue to use
 /// [`check_auth`], so an ingestion token cannot authorize query or node APIs.
 pub fn check_otlp_auth(req: Request<()>) -> Result<Request<()>, Status> {
-    check_auth_inner(req, true)
+    check_auth_inner(req, true, true)
 }
 
 fn check_auth_inner(
     req: Request<()>,
     allow_org_ingestion_token: bool,
+    is_write: bool,
 ) -> Result<Request<()>, Status> {
     let cfg = config::get_config();
     let metadata = req.metadata();
@@ -108,14 +119,16 @@ fn check_auth_inner(
             return Err(Status::unauthenticated("No valid auth token[4]"));
         };
 
-        // `allow_org_ingestion_token` marks the OTLP logs/metrics/traces
-        // services — i.e. this request is an ingest. A read-only account has no
-        // write path over HTTP, so it must not gain one over gRPC either.
-        // Enterprise builds also run their own RBAC on top of this.
-        if allow_org_ingestion_token && user.role.is_read_only() {
-            log::warn!("Read only account attempted OTLP gRPC ingestion: {user_id}");
+        // A read-only account has no write path over HTTP, so it must not gain
+        // one over gRPC either. Keyed on the service's declared `is_write`
+        // rather than on `allow_org_ingestion_token`, which only marks the OTLP
+        // services and would leave the internal ingest service uncovered.
+        // Enterprise defers to OpenFGA, exactly as the HTTP gate does.
+        #[cfg(not(feature = "enterprise"))]
+        if is_write && user.role.is_read_only() {
+            log::warn!("Read only account {user_id} denied gRPC write");
             return Err(Status::permission_denied(
-                "Read only account: this operation is not permitted",
+                common::meta::read_only_routes::READ_ONLY_DENIED,
             ));
         }
 

--- a/src/api/grpc/src/handler/grpc/auth/mod.rs
+++ b/src/api/grpc/src/handler/grpc/auth/mod.rs
@@ -49,6 +49,10 @@ fn check_auth_inner(
     allow_org_ingestion_token: bool,
     is_write: bool,
 ) -> Result<Request<()>, Status> {
+    // Only the OSS read-only gate consults this; enterprise defers to OpenFGA.
+    #[cfg(feature = "enterprise")]
+    let _ = is_write;
+
     let cfg = config::get_config();
     let metadata = req.metadata();
     if !metadata.contains_key(&cfg.grpc.org_header_key) && !metadata.contains_key("authorization") {
@@ -119,6 +123,20 @@ fn check_auth_inner(
             return Err(Status::unauthenticated("No valid auth token[4]"));
         };
 
+        // Authenticate first. The read-only check below is an *authorization*
+        // decision and must not run against an unverified caller: doing so
+        // answers `permission_denied` rather than `unauthenticated` to anyone
+        // who merely guesses a read-only account's email, confirming both that
+        // the account exists and that it is read only.
+        let authenticated = user.token.eq(&credentials.password) || {
+            let in_pass = get_hash(&credentials.password, &user.salt);
+            user_id.eq(&user.email)
+                && (credentials.password.eq(&user.password) || in_pass.eq(&user.password))
+        };
+        if !authenticated {
+            return Err(Status::unauthenticated("No valid auth token[5]"));
+        }
+
         // A read-only account has no write path over HTTP, so it must not gain
         // one over gRPC either. Keyed on the service's declared `is_write`
         // rather than on `allow_org_ingestion_token`, which only marks the OTLP
@@ -132,30 +150,16 @@ fn check_auth_inner(
             ));
         }
 
-        if user.token.eq(&credentials.password) {
-            let mut req = req;
-            let user_id_metadata = MetadataValue::try_from(&user_id).unwrap();
-            req.metadata_mut().append("user_id", user_id_metadata);
-            return Ok(req);
-        }
-        let in_pass = get_hash(&credentials.password, &user.salt);
-        if user_id.eq(&user.email)
-            && (credentials.password.eq(&user.password) || in_pass.eq(&user.password))
-        {
-            let mut req = req;
-            let user_id_metadata = MetadataValue::try_from(&user_id).unwrap();
-            req.metadata_mut().append("user_id", user_id_metadata);
-
-            Ok(req)
-        } else {
-            Err(Status::unauthenticated("No valid auth token[5]"))
-        }
+        let mut req = req;
+        let user_id_metadata = MetadataValue::try_from(&user_id).unwrap();
+        req.metadata_mut().append("user_id", user_id_metadata);
+        Ok(req)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use common::infra::config::{ORG_INGESTION_TOKENS, ORG_USERS};
+    use common::infra::config::{ORG_INGESTION_TOKENS, ORG_USERS, USERS};
     use config::{
         cache_instance_id, get_config,
         meta::user::{User, UserRole},
@@ -163,6 +167,71 @@ mod tests {
     use infra::table::org_users::OrgUserRecord;
 
     use super::*;
+
+    /// Registers a read-only Viewer in `default` and returns a request bearing
+    /// `authorization`/`organization` metadata for the given Basic credential.
+    #[cfg(not(feature = "enterprise"))]
+    fn viewer_request(basic: &str) -> tonic::Request<()> {
+        cache_instance_id("instance");
+        USERS.insert(
+            "viewer@example.com".to_string(),
+            infra::table::users::UserRecord {
+                email: "viewer@example.com".to_string(),
+                first_name: "Read".to_string(),
+                last_name: "Only".to_string(),
+                password: "Complexpass#123".to_string(),
+                salt: "Complexpass#123".to_string(),
+                is_root: false,
+                password_ext: Some("Complexpass#123".to_string()),
+                user_type: config::meta::user::UserType::Internal,
+                created_at: 0,
+                updated_at: 0,
+            },
+        );
+        ORG_USERS.insert(
+            "default/viewer@example.com".to_string(),
+            OrgUserRecord {
+                role: UserRole::Viewer,
+                token: "viewer-token".to_string(),
+                rum_token: None,
+                org_id: "default".to_string(),
+                email: "viewer@example.com".to_string(),
+                created_at: 0,
+                allow_static_token: true,
+            },
+        );
+
+        let mut request = tonic::Request::new(());
+        let meta = request.metadata_mut();
+        meta.insert("authorization", basic.parse().unwrap());
+        meta.insert("organization", "default".parse().unwrap());
+        request
+    }
+
+    /// A read-only account is refused on a write service but still reaches the
+    /// read services, which is the whole point of the role.
+    #[cfg(not(feature = "enterprise"))]
+    #[tokio::test]
+    async fn test_read_only_account_denied_on_write_service() {
+        let basic = "basic dmlld2VyQGV4YW1wbGUuY29tOkNvbXBsZXhwYXNzIzEyMw==";
+
+        let err = check_write_auth(viewer_request(basic)).unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+        assert!(check_otlp_auth(viewer_request(basic)).is_err());
+        assert!(check_auth(viewer_request(basic)).is_ok());
+    }
+
+    /// Authorization must not be decided before authentication: a wrong password
+    /// on a write service has to read as `unauthenticated`, never
+    /// `permission_denied` — the latter would confirm to an unauthenticated
+    /// caller that the account exists and is read only.
+    #[cfg(not(feature = "enterprise"))]
+    #[tokio::test]
+    async fn test_bad_password_is_unauthenticated_not_permission_denied() {
+        let request = viewer_request("basic dmlld2VyQGV4YW1wbGUuY29tOldyb25nUGFzcyMxMjM=");
+        let err = check_write_auth(request).unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unauthenticated);
+    }
 
     #[tokio::test]
     async fn test_check_no_auth() {

--- a/src/api/grpc/src/handler/grpc/request/ingest.rs
+++ b/src/api/grpc/src/handler/grpc/request/ingest.rs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use common::utils::grpc_auth::{authenticated_org, bind_org};
 use config::{
     meta::{otlp::OtlpRequestType, stream::StreamType},
     metrics,
@@ -38,7 +39,9 @@ impl Ingest for Ingester {
         request: Request<IngestionRequest>,
     ) -> Result<Response<IngestionResponse>, Status> {
         let start = std::time::Instant::now();
-        let req = request.into_inner();
+        let authenticated_org = authenticated_org(&request)?;
+        let mut req = request.into_inner();
+        bind_org(&mut req.org_id, authenticated_org);
         let org_id = req.org_id;
         let stream_type: StreamType = req.stream_type.into();
         let stream_name = req.stream_name;

--- a/src/api/grpc/src/handler/grpc/request/metrics/querier.rs
+++ b/src/api/grpc/src/handler/grpc/request/metrics/querier.rs
@@ -15,6 +15,7 @@
 
 use std::pin::Pin;
 
+use common::utils::grpc_auth::{authenticated_org, bind_org};
 use config::{meta::stream::StreamType, metrics};
 use futures::Stream;
 use infra::errors;
@@ -49,7 +50,10 @@ impl Metrics for MetricsQuerier {
             global::get_text_map_propagator(|prop| prop.extract(&MetadataMap(req.metadata())));
         let _ = tracing::Span::current().set_parent(parent_cx);
 
-        let req: &MetricsQueryRequest = req.get_ref();
+        let authenticated_org = authenticated_org(&req)?;
+        let mut owned_req = req.into_inner();
+        bind_org(&mut owned_req.org_id, authenticated_org);
+        let req: &MetricsQueryRequest = &owned_req;
         let org_id = &req.org_id;
         let stream_type = StreamType::Metrics.as_str();
 
@@ -104,7 +108,9 @@ impl Metrics for MetricsQuerier {
     ) -> Result<Response<Self::DataStream>, Status> {
         let cap = std::cmp::max(2, config::get_config().limit.cpu_num);
         let (tx, rx) = mpsc::channel::<Result<MetricsQueryResponse, Status>>(cap);
+        let authenticated_org = authenticated_org(&req)?;
         let mut req: MetricsQueryRequest = req.into_inner();
+        bind_org(&mut req.org_id, authenticated_org);
         req.query.as_mut().unwrap().query_data = true;
 
         log::info!(

--- a/src/api/grpc/src/server.rs
+++ b/src/api/grpc/src/server.rs
@@ -253,9 +253,7 @@ fn authenticated<S>(service: S) -> InterceptedService<S, AuthInterceptor> {
     InterceptedService::new(service, check_auth)
 }
 
-/// For services that write data on the internal cluster credentials — a
-/// read-only account is refused, unlike the read services wrapped by
-/// [`authenticated`].
+/// Like [`authenticated`], but refuses read-only accounts.
 fn write_authenticated<S>(service: S) -> InterceptedService<S, AuthInterceptor> {
     InterceptedService::new(service, check_write_auth)
 }

--- a/src/api/grpc/src/server.rs
+++ b/src/api/grpc/src/server.rs
@@ -39,7 +39,7 @@ use tonic::{
 
 use crate::{
     handler::grpc::{
-        auth::{check_auth, check_otlp_auth},
+        auth::{check_auth, check_otlp_auth, check_write_auth},
         flight::FlightServiceImpl,
         request::{
             event::Eventer,
@@ -152,7 +152,7 @@ async fn run_common(
     let trace_svc = otlp_authenticated(trace_svc);
     let logs_svc = otlp_authenticated(logs_svc);
     let query_cache_svc = authenticated(query_cache_svc);
-    let ingest_svc = authenticated(ingest_svc);
+    let ingest_svc = write_authenticated(ingest_svc);
     let streams_svc = authenticated(streams_svc);
     let flight_svc = authenticated(flight_svc);
     let node_svc = authenticated(node_svc);
@@ -251,6 +251,13 @@ type AuthInterceptor = fn(tonic::Request<()>) -> Result<tonic::Request<()>, toni
 
 fn authenticated<S>(service: S) -> InterceptedService<S, AuthInterceptor> {
     InterceptedService::new(service, check_auth)
+}
+
+/// For services that write data on the internal cluster credentials — a
+/// read-only account is refused, unlike the read services wrapped by
+/// [`authenticated`].
+fn write_authenticated<S>(service: S) -> InterceptedService<S, AuthInterceptor> {
+    InterceptedService::new(service, check_write_auth)
 }
 
 fn otlp_authenticated<S>(service: S) -> InterceptedService<S, AuthInterceptor> {

--- a/src/api/grpc/src/server.rs
+++ b/src/api/grpc/src/server.rs
@@ -145,13 +145,13 @@ async fn run_common(
         .max_decoding_message_size(cfg.grpc.max_message_size * 1024 * 1024)
         .max_encoding_message_size(cfg.grpc.max_message_size * 1024 * 1024);
 
-    let event_svc = authenticated(event_svc);
+    let event_svc = write_authenticated(event_svc);
     let search_svc = authenticated(search_svc);
     let metrics_svc = authenticated(metrics_svc);
     let metrics_ingest_svc = otlp_authenticated(metrics_ingest_svc);
     let trace_svc = otlp_authenticated(trace_svc);
     let logs_svc = otlp_authenticated(logs_svc);
-    let query_cache_svc = authenticated(query_cache_svc);
+    let query_cache_svc = write_authenticated(query_cache_svc);
     let ingest_svc = write_authenticated(ingest_svc);
     let streams_svc = authenticated(streams_svc);
     let flight_svc = authenticated(flight_svc);

--- a/src/api/management/src/request/users/mod.rs
+++ b/src/api/management/src/request/users/mod.rs
@@ -235,15 +235,8 @@ pub async fn save(
         ("x-o2-mcp" = json!({"description": "Update user details", "category": "users"}))
     )
 )]
-/// Is `target` the caller's own account?
-///
-/// Both sides must already be canonical (lowercased). This is the *only* thing
-/// standing between a caller and the privileged `OtherUpdate` path in
-/// [`openobserve_core::users::update_user`], so it has to agree with how every
-/// layer below identifies a user — and those are all case-insensitive
-/// (`get_cached_user_org` lowercases its key, the org_users queries filter on
-/// `LOWER(email)`). A target that differs only in case must therefore be a
-/// self-update, not an update of somebody else.
+/// Is `target` the caller's own account? Both sides must already be lowercased,
+/// since every user lookup below this is case-insensitive.
 fn update_mode_for(caller: &str, target: &str) -> UserUpdateMode {
     if caller.eq(target) {
         UserUpdateMode::SelfUpdate
@@ -257,12 +250,8 @@ pub async fn update(
     Headers(user_email): Headers<UserEmail>,
     axum::Json(user): axum::Json<UpdateUser>,
 ) -> Response {
-    // Lowercased, like the create path above and like every storage lookup
-    // (`get_cached_user_org` lowercases its cache key; the org_users queries
-    // filter on `LOWER(email)`). Without this, an email differing only in case
-    // resolves to the caller's own record everywhere downstream while the
-    // `update_mode` comparison below still reads it as somebody *else*, which
-    // is what turns a self-update into a role change nobody is allowed to make.
+    // Lowercased like the create path, so a differently-cased spelling of the
+    // caller's own email cannot read as an update of somebody else.
     let email_id = email_id.trim().to_lowercase();
     #[cfg(not(feature = "enterprise"))]
     let mut user = user;
@@ -314,14 +303,10 @@ pub async fn update(
             .unwrap();
     }
 
-    // Only normalise a role the caller actually asked for. Forcing a role on
-    // every update — as this used to do — would silently promote a read-only
-    // account to Admin the moment anyone edited its name or password.
+    // Only normalise a role the caller actually asked for; forcing one on every
+    // update would promote a Viewer to Admin on any profile edit.
     #[cfg(not(feature = "enterprise"))]
     if let Some(role_request) = user.role.as_mut() {
-        // Resolved through `UserOrgRole::from`, the same conversion the create
-        // path and `core::users` use, so a role spelled "Viewer" resolves the
-        // same way here as it does there.
         let requested = UserOrgRole::from(&*role_request).base_role;
         role_request.role = get_supported_role(&requested).to_string();
         role_request.custom = None;
@@ -1236,12 +1221,8 @@ mod tests {
         assert_eq!(role_response.value, "admin");
     }
 
-    /// A path email differing from the caller's only in case must still be a
-    /// self-update. Read it as `OtherUpdate` and the caller lands on the
-    /// privileged branch of `update_user`, which skips the "Self role cannot be
-    /// upgraded" guard — that is a read-only account handing itself Admin.
-    /// The handler lowercases the path segment before this runs, so the two
-    /// spellings converge here.
+    /// A path email differing only in case is still a self-update; reading it as
+    /// `OtherUpdate` skips the "Self role cannot be upgraded" guard.
     #[test]
     fn test_case_varied_self_email_is_a_self_update() {
         let caller = "viewer@example.com";
@@ -1262,8 +1243,7 @@ mod tests {
         );
     }
 
-    /// OSS offers exactly two assignable roles: Admin and the read-only Viewer.
-    /// This is what the role dropdown in the UI is built from.
+    /// OSS offers exactly two assignable roles; the UI dropdown is built from this.
     #[cfg(not(feature = "enterprise"))]
     #[test]
     fn test_assignable_roles_in_oss_include_viewer() {

--- a/src/api/management/src/request/users/mod.rs
+++ b/src/api/management/src/request/users/mod.rs
@@ -235,12 +235,35 @@ pub async fn save(
         ("x-o2-mcp" = json!({"description": "Update user details", "category": "users"}))
     )
 )]
+/// Is `target` the caller's own account?
+///
+/// Both sides must already be canonical (lowercased). This is the *only* thing
+/// standing between a caller and the privileged `OtherUpdate` path in
+/// [`openobserve_core::users::update_user`], so it has to agree with how every
+/// layer below identifies a user — and those are all case-insensitive
+/// (`get_cached_user_org` lowercases its key, the org_users queries filter on
+/// `LOWER(email)`). A target that differs only in case must therefore be a
+/// self-update, not an update of somebody else.
+fn update_mode_for(caller: &str, target: &str) -> UserUpdateMode {
+    if caller.eq(target) {
+        UserUpdateMode::SelfUpdate
+    } else {
+        UserUpdateMode::OtherUpdate
+    }
+}
+
 pub async fn update(
     Path((org_id, email_id)): Path<(String, String)>,
     Headers(user_email): Headers<UserEmail>,
     axum::Json(user): axum::Json<UpdateUser>,
 ) -> Response {
-    let email_id = email_id.trim().to_string();
+    // Lowercased, like the create path above and like every storage lookup
+    // (`get_cached_user_org` lowercases its cache key; the org_users queries
+    // filter on `LOWER(email)`). Without this, an email differing only in case
+    // resolves to the caller's own record everywhere downstream while the
+    // `update_mode` comparison below still reads it as somebody *else*, which
+    // is what turns a self-update into a role change nobody is allowed to make.
+    let email_id = email_id.trim().to_lowercase();
     #[cfg(not(feature = "enterprise"))]
     let mut user = user;
     if user.eq(&UpdateUser::default()) {
@@ -305,11 +328,7 @@ pub async fn update(
     }
 
     let initiator_id = &user_email.user_id;
-    let update_mode = if user_email.user_id.eq(&email_id) {
-        UserUpdateMode::SelfUpdate
-    } else {
-        UserUpdateMode::OtherUpdate
-    };
+    let update_mode = update_mode_for(&user_email.user_id, &email_id);
     match users::update_user(&org_id, &email_id, update_mode, initiator_id, user).await {
         Ok(resp) => resp,
         Err(e) => MetaHttpResponse::internal_error(e),
@@ -1215,6 +1234,32 @@ mod tests {
         assert!(result.is_some());
         let role_response = result.unwrap();
         assert_eq!(role_response.value, "admin");
+    }
+
+    /// A path email differing from the caller's only in case must still be a
+    /// self-update. Read it as `OtherUpdate` and the caller lands on the
+    /// privileged branch of `update_user`, which skips the "Self role cannot be
+    /// upgraded" guard — that is a read-only account handing itself Admin.
+    /// The handler lowercases the path segment before this runs, so the two
+    /// spellings converge here.
+    #[test]
+    fn test_case_varied_self_email_is_a_self_update() {
+        let caller = "viewer@example.com";
+        for target in [
+            "Viewer@example.com",
+            "VIEWER@EXAMPLE.COM",
+            "  viewer@example.com  ",
+        ] {
+            assert_eq!(
+                update_mode_for(caller, &target.trim().to_lowercase()),
+                UserUpdateMode::SelfUpdate,
+                "{target} names the caller's own account"
+            );
+        }
+        assert_eq!(
+            update_mode_for(caller, "someone.else@example.com"),
+            UserUpdateMode::OtherUpdate
+        );
     }
 
     /// OSS offers exactly two assignable roles: Admin and the read-only Viewer.

--- a/src/api/management/src/request/users/mod.rs
+++ b/src/api/management/src/request/users/mod.rs
@@ -45,6 +45,8 @@ use {
     openobserve_core::auth::check_permissions,
 };
 
+#[cfg(not(feature = "enterprise"))]
+use crate::common::meta::user::get_supported_role;
 use crate::{
     common::meta::{
         self,
@@ -197,7 +199,7 @@ pub async fn save(
 
     #[cfg(not(feature = "enterprise"))]
     {
-        user.role.base_role = UserRole::Admin;
+        user.role.base_role = get_supported_role(&user.role.base_role);
     }
     match users::post_user(&org_id, user, &initiator_id).await {
         Ok(resp) => resp,
@@ -289,13 +291,21 @@ pub async fn update(
             .unwrap();
     }
 
+    // Only normalise a role the caller actually asked for. Forcing a role on
+    // every update — as this used to do — would silently promote a read-only
+    // account to Admin the moment anyone edited its name or password.
     #[cfg(not(feature = "enterprise"))]
-    {
+    if let Some(role_request) = user.role.as_ref() {
+        let requested = role_request
+            .role
+            .parse::<UserRole>()
+            .unwrap_or(UserRole::Admin);
         user.role = Some(UserRoleRequest {
-            role: UserRole::Admin.to_string(),
+            role: get_supported_role(&requested).to_string(),
             custom: None,
         });
     }
+
     let initiator_id = &user_email.user_id;
     let update_mode = if user_email.user_id.eq(&email_id) {
         UserUpdateMode::SelfUpdate
@@ -1207,5 +1217,36 @@ mod tests {
         assert!(result.is_some());
         let role_response = result.unwrap();
         assert_eq!(role_response.value, "admin");
+    }
+
+    /// OSS offers exactly two assignable roles: Admin and the read-only Viewer.
+    /// This is what the role dropdown in the UI is built from.
+    #[cfg(not(feature = "enterprise"))]
+    #[test]
+    fn test_assignable_roles_in_oss_include_viewer() {
+        let values = get_roles()
+            .iter()
+            .filter_map(check_role_available)
+            .map(|r| r.value)
+            .collect::<Vec<_>>();
+        assert_eq!(values, vec!["admin".to_string(), "viewer".to_string()]);
+    }
+
+    #[cfg(not(feature = "enterprise"))]
+    #[test]
+    fn test_get_supported_role() {
+        // Viewer is the one non-admin role OSS can enforce on its own.
+        assert_eq!(get_supported_role(&UserRole::Viewer), UserRole::Viewer);
+        // Everything else collapses to Admin, as it always has in OSS —
+        // including Root, so these endpoints cannot mint a privileged account.
+        for role in [
+            UserRole::Admin,
+            UserRole::Editor,
+            UserRole::User,
+            UserRole::Root,
+            UserRole::ServiceAccount,
+        ] {
+            assert_eq!(get_supported_role(&role), UserRole::Admin);
+        }
     }
 }

--- a/src/api/management/src/request/users/mod.rs
+++ b/src/api/management/src/request/users/mod.rs
@@ -295,15 +295,13 @@ pub async fn update(
     // every update — as this used to do — would silently promote a read-only
     // account to Admin the moment anyone edited its name or password.
     #[cfg(not(feature = "enterprise"))]
-    if let Some(role_request) = user.role.as_ref() {
-        let requested = role_request
-            .role
-            .parse::<UserRole>()
-            .unwrap_or(UserRole::Admin);
-        user.role = Some(UserRoleRequest {
-            role: get_supported_role(&requested).to_string(),
-            custom: None,
-        });
+    if let Some(role_request) = user.role.as_mut() {
+        // Resolved through `UserOrgRole::from`, the same conversion the create
+        // path and `core::users` use, so a role spelled "Viewer" resolves the
+        // same way here as it does there.
+        let requested = UserOrgRole::from(&*role_request).base_role;
+        role_request.role = get_supported_role(&requested).to_string();
+        role_request.custom = None;
     }
 
     let initiator_id = &user_email.user_id;
@@ -1230,23 +1228,5 @@ mod tests {
             .map(|r| r.value)
             .collect::<Vec<_>>();
         assert_eq!(values, vec!["admin".to_string(), "viewer".to_string()]);
-    }
-
-    #[cfg(not(feature = "enterprise"))]
-    #[test]
-    fn test_get_supported_role() {
-        // Viewer is the one non-admin role OSS can enforce on its own.
-        assert_eq!(get_supported_role(&UserRole::Viewer), UserRole::Viewer);
-        // Everything else collapses to Admin, as it always has in OSS —
-        // including Root, so these endpoints cannot mint a privileged account.
-        for role in [
-            UserRole::Admin,
-            UserRole::Editor,
-            UserRole::User,
-            UserRole::Root,
-            UserRole::ServiceAccount,
-        ] {
-            assert_eq!(get_supported_role(&role), UserRole::Admin);
-        }
     }
 }

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -53,6 +53,7 @@ tracing.workspace = true
 tracing-opentelemetry.workspace = true
 uaparser.workspace = true
 url.workspace = true
+urlencoding.workspace = true
 utoipa.workspace = true
 config.workspace = true
 infra.workspace = true

--- a/src/common/src/meta/ingestion_routes.rs
+++ b/src/common/src/meta/ingestion_routes.rs
@@ -35,17 +35,7 @@
 
 use axum::http::Method;
 
-/// One segment of a declared route pattern.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Seg {
-    /// A fixed path segment that must match exactly (e.g. `_bulk`, `traces`).
-    Lit(&'static str),
-    /// A single path parameter — matches any one non-empty segment
-    /// (`{org_id}`, `{stream_name}`, `{name}`, ...). It deliberately does NOT
-    /// match an ingestion keyword by accident because matching is positional:
-    /// a stream literally named `traces` only ever lands in a `Param` slot.
-    Param,
-}
+use super::route_match::{self, Seg};
 
 /// What an ingestion-facing route is, for authorization purposes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -220,22 +210,6 @@ static INGESTION_ROUTES: &[IngestionRoute] = &[
     },
 ];
 
-/// The `/v2/...` API prefix, stripped before matching so `/v2/{org}/_bulk`
-/// classifies identically to `/{org}/_bulk`.
-const V2_API_PREFIX: &str = "v2";
-
-/// Does this segment pattern list match these path segments?
-fn segments_match(patterns: &[Seg], columns: &[&str]) -> bool {
-    if patterns.len() != columns.len() {
-        return false;
-    }
-    patterns.iter().zip(columns).all(|(pat, col)| match pat {
-        Seg::Lit(lit) => col == lit,
-        // A param matches any single non-empty segment.
-        Seg::Param => !col.is_empty(),
-    })
-}
-
 /// Classify a request against the ingestion-route table.
 ///
 /// `path` is the request path with the `/api/` and base-uri prefix already
@@ -250,13 +224,7 @@ fn segments_match(patterns: &[Seg], columns: &[&str]) -> bool {
 /// everything else — including data-read routes such as `.../traces/latest`,
 /// which are intentionally not in the table.
 pub fn classify(method: &Method, path: &str) -> Option<IngestionKind> {
-    let path = path.strip_prefix('/').unwrap_or(path);
-    // Normalise the optional `/v2/{org}/...` prefix to `/{org}/...`.
-    let path = path
-        .strip_prefix(V2_API_PREFIX)
-        .and_then(|rest| rest.strip_prefix('/'))
-        .unwrap_or(path);
-
+    let path = route_match::strip_api_prefixes(path);
     let method = method.as_str();
 
     // The ES root version ping is the sole ingestion route registered with a
@@ -271,16 +239,16 @@ pub fn classify(method: &Method, path: &str) -> Option<IngestionKind> {
         return Some(IngestionKind::EsHandshakeRead);
     }
 
-    // Everything else matches on exact segment shape. A single trailing empty
-    // segment (trailing slash) is dropped so `.../_bulk/` == `.../_bulk`.
-    let mut columns: Vec<&str> = path.split('/').collect();
-    if columns.len() > 1 && columns.last() == Some(&"") {
-        columns.pop();
-    }
+    // Everything else matches on exact segment shape.
+    let columns = route_match::columns(path);
 
     INGESTION_ROUTES
         .iter()
-        .find(|route| route.methods.contains(&method) && segments_match(route.segments, &columns))
+        .find(|route| {
+            route.methods.contains(&method)
+                // The ingestion table declares no subject-constrained routes.
+                && route_match::segments_match(route.segments, &columns, |_| false)
+        })
         .map(|route| route.kind)
 }
 

--- a/src/common/src/meta/mod.rs
+++ b/src/common/src/meta/mod.rs
@@ -22,7 +22,11 @@ pub mod maxmind;
 pub mod middleware_data;
 pub mod organization;
 pub mod proxy;
+/// Read-only account policy is enforced only in OSS builds; enterprise defers
+/// to OpenFGA.
+#[cfg(not(feature = "enterprise"))]
 pub mod read_only_routes;
+pub(crate) mod route_match;
 pub mod saved_view;
 pub mod service;
 pub mod service_account;

--- a/src/common/src/meta/mod.rs
+++ b/src/common/src/meta/mod.rs
@@ -22,6 +22,7 @@ pub mod maxmind;
 pub mod middleware_data;
 pub mod organization;
 pub mod proxy;
+pub mod read_only_routes;
 pub mod saved_view;
 pub mod service;
 pub mod service_account;

--- a/src/common/src/meta/read_only_routes.rs
+++ b/src/common/src/meta/read_only_routes.rs
@@ -196,6 +196,19 @@ static READ_ONLY_ROUTES: &[ReadOnlyRoute] = &[
     },
 ];
 
+/// Routes refused to a read-only account despite a safe method, because they
+/// hand back a credential that would let the caller write. Checked before the
+/// safe-method allowance below.
+static CREDENTIAL_ROUTES: &[ReadOnlyRoute] = &[
+    // `/{org}/passcode` — returns the org-wide ingestion token unmasked, and
+    // ingesting with that token authenticates with no role at all, so the
+    // read-only gate would never see the write.
+    ReadOnlyRoute {
+        segments: &[Param, Lit("passcode")],
+        method: "GET",
+    },
+];
+
 /// HTTP methods that cannot mutate state and are therefore always allowed.
 fn is_safe_method(method: &Method) -> bool {
     matches!(*method, Method::GET | Method::HEAD | Method::OPTIONS)
@@ -218,25 +231,74 @@ fn is_self_email(segment: &str, user_email: &str) -> bool {
 /// `user_email` is the caller, used only by the self-service rows. A `false`
 /// becomes a `403`.
 pub fn is_request_allowed(method: &Method, path: &str, user_email: &str) -> bool {
+    let matches = |routes: &[ReadOnlyRoute], method: &str, columns: &[&str]| {
+        routes.iter().any(|route| {
+            route.method == method
+                && route_match::segments_match(route.segments, columns, |col| {
+                    is_self_email(col, user_email)
+                })
+        })
+    };
+    let method_str = method.as_str();
+    let candidates = route_match::candidate_columns(path);
+
+    if candidates
+        .iter()
+        .any(|columns| matches(CREDENTIAL_ROUTES, method_str, columns))
+    {
+        return false;
+    }
     if is_safe_method(method) {
         return true;
     }
 
-    let path = route_match::strip_api_prefixes(path);
-    let method = method.as_str();
-    let columns = route_match::columns(path);
-
-    READ_ONLY_ROUTES.iter().any(|route| {
-        route.method == method
-            && route_match::segments_match(route.segments, &columns, |col| {
-                is_self_email(col, user_email)
-            })
-    })
+    candidates
+        .iter()
+        .any(|columns| matches(READ_ONLY_ROUTES, method_str, columns))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `GET /{org}/passcode` returns the org-wide ingestion token unmasked, and
+    /// that token authenticates with no role, so the gate would never see the
+    /// writes it buys. It must not ride the safe-method allowance.
+    #[test]
+    fn credential_bearing_reads_are_refused() {
+        let viewer = "viewer@example.com";
+        assert!(!is_request_allowed(
+            &Method::GET,
+            "default/passcode",
+            viewer
+        ));
+        assert!(!is_request_allowed(
+            &Method::GET,
+            "/v2/default/passcode",
+            viewer
+        ));
+        // Rotating it was already refused as a write method.
+        assert!(!is_request_allowed(
+            &Method::PUT,
+            "default/passcode",
+            viewer
+        ));
+        // Ordinary reads are untouched.
+        assert!(is_request_allowed(
+            &Method::GET,
+            "default/dashboards",
+            viewer
+        ));
+    }
+
+    /// An org literally named `v2` must still reach the read-only routes.
+    #[test]
+    fn an_org_named_v2_is_not_mistaken_for_the_api_prefix() {
+        let viewer = "viewer@example.com";
+        assert!(is_request_allowed(&Method::POST, "v2/_search", viewer));
+        assert!(!is_request_allowed(&Method::GET, "v2/passcode", viewer));
+        assert!(!is_request_allowed(&Method::POST, "v2/dashboards", viewer));
+    }
 
     const ME: &str = "viewer@example.com";
 

--- a/src/common/src/meta/read_only_routes.rs
+++ b/src/common/src/meta/read_only_routes.rs
@@ -196,15 +196,32 @@ static READ_ONLY_ROUTES: &[ReadOnlyRoute] = &[
     },
 ];
 
-/// Routes refused to a read-only account despite a safe method, because they
-/// hand back a credential that would let the caller write. Checked before the
-/// safe-method allowance below.
-static CREDENTIAL_ROUTES: &[ReadOnlyRoute] = &[
+/// Routes refused despite a safe method, checked before the safe-method
+/// allowance. `GET` is only presumed harmless — where a handler breaks that
+/// presumption it needs a row here.
+static SAFE_METHOD_EXCEPTIONS: &[ReadOnlyRoute] = &[
+    // ---- Hands back a credential that buys a write ----
     // `/{org}/passcode` — returns the org-wide ingestion token unmasked, and
     // ingesting with that token authenticates with no role at all, so the
     // read-only gate would never see the write.
     ReadOnlyRoute {
         segments: &[Param, Lit("passcode")],
+        method: "GET",
+    },
+    // ---- Mutates server state behind a GET ----
+    // These are node routes, not org routes, so segment 0 is the literal
+    // `node`. Unlike `/config/reload`, none of them checks the caller's role.
+    // `/node/reload?module=all` rebuilds every cache on the node.
+    ReadOnlyRoute {
+        segments: &[Lit("node"), Lit("reload")],
+        method: "GET",
+    },
+    ReadOnlyRoute {
+        segments: &[Lit("node"), Lit("refresh_nodes_list")],
+        method: "GET",
+    },
+    ReadOnlyRoute {
+        segments: &[Lit("node"), Lit("refresh_user_sessions")],
         method: "GET",
     },
 ];
@@ -244,7 +261,7 @@ pub fn is_request_allowed(method: &Method, path: &str, user_email: &str) -> bool
 
     if candidates
         .iter()
-        .any(|columns| matches(CREDENTIAL_ROUTES, method_str, columns))
+        .any(|columns| matches(SAFE_METHOD_EXCEPTIONS, method_str, columns))
     {
         return false;
     }
@@ -289,6 +306,29 @@ mod tests {
             "default/dashboards",
             viewer
         ));
+    }
+
+    /// Node routes that rebuild caches behind a `GET`. They carry no role check
+    /// of their own, unlike `/config/reload`, which is root-only.
+    #[test]
+    fn cache_mutating_gets_are_refused() {
+        let viewer = "viewer@example.com";
+        assert!(!is_request_allowed(&Method::GET, "node/reload", viewer));
+        assert!(!is_request_allowed(&Method::GET, "/node/reload", viewer));
+        assert!(!is_request_allowed(
+            &Method::GET,
+            "node/refresh_nodes_list",
+            viewer
+        ));
+        assert!(!is_request_allowed(
+            &Method::GET,
+            "node/refresh_user_sessions",
+            viewer
+        ));
+        // The genuinely read-only node routes are untouched.
+        assert!(is_request_allowed(&Method::GET, "node/status", viewer));
+        assert!(is_request_allowed(&Method::GET, "node/list", viewer));
+        assert!(is_request_allowed(&Method::GET, "node/metrics", viewer));
     }
 
     /// An org literally named `v2` must still reach the read-only routes.

--- a/src/common/src/meta/read_only_routes.rs
+++ b/src/common/src/meta/read_only_routes.rs
@@ -13,44 +13,24 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//! What a **read only account** is allowed to do.
+//! What a read-only account (`Viewer`, `SreAgent`) is allowed to do in OSS
+//! builds, which have no OpenFGA to enforce roles for them.
 //!
-//! Enterprise builds answer this question with OpenFGA: every route carries a
-//! declared permission and the authorization model decides. OSS builds have no
-//! FGA, so `Viewer` (and the system-managed `SreAgent`) would otherwise be
-//! indistinguishable from `Admin` once authenticated. This module is the OSS
-//! answer — a single, declarative source of truth that the auth layer consults
-//! for every authenticated request made by a read-only account.
+//! Three things pass: safe HTTP methods, the query-by-POST routes declared in
+//! [`READ_ONLY_ROUTES`], and self-service maintenance of the caller's own
+//! account. Everything else, ingestion included, is refused.
 //!
-//! The rule is deliberately narrow, so that "read only" means exactly that:
-//!
-//! 1. **Safe HTTP methods pass.** `GET`, `HEAD` and `OPTIONS` never mutate.
-//! 2. **A short allowlist of query-by-POST routes passes.** Search and PromQL-style endpoints use
-//!    `POST` only because the query travels in the request body; they persist nothing. Each row in
-//!    [`READ_ONLY_ROUTES`] is an endpoint of that kind and nothing else — no "test", "preview" or
-//!    "create" endpoints, however harmless they look.
-//! 3. **A read-only account may maintain its own account.** Updating one's own profile/password and
-//!    one's own per-user UI settings is self-service, not a privileged write, so it is allowed when
-//!    the email in the path is the caller's own.
-//!
-//! Everything else — every other `POST`/`PUT`/`PATCH`/`DELETE`, including all
-//! ingestion — is refused. Adding a new read-only endpoint that uses a write
-//! method means adding a row here and nothing else.
-//!
-//! Paths are matched with the `/api/` (and base-uri) prefix already stripped,
-//! so segment 0 is `{org_id}`; an optional `/v2/` prefix is normalised away
-//! first, exactly like [`super::ingestion_routes`].
+//! Paths arrive with the `/api/` and base-uri prefix stripped, so segment 0 is
+//! `{org_id}`; a `/v2/` prefix is normalised away like in
+//! [`super::ingestion_routes`].
 
-/// `Subject` is the shared matcher's "must equal the caller-supplied subject"
-/// pattern; here the subject is always the caller's own email, so the table
-/// reads `SelfEmail`. This is what turns "update a user" into "update *my* user".
+/// The matcher's subject pattern; here the subject is always the caller's email.
 use Seg::{Lit, Param, Subject as SelfEmail};
 use axum::http::Method;
 
 use super::route_match::{self, Seg};
 
-/// The user-facing reason a read-only account is refused. Lives here, next to
-/// the policy it describes, because both the HTTP and gRPC entry points report it.
+/// The refusal message, shared by the HTTP and gRPC entry points.
 pub const READ_ONLY_DENIED: &str = "Read only account: this operation is not permitted";
 
 /// A route a read-only account may reach despite its write-ish HTTP method.
@@ -61,16 +41,12 @@ struct ReadOnlyRoute {
     method: &'static str,
 }
 
-/// The authoritative table of write-method routes that a read-only account may
-/// still call. Mirrors `src/api/http/src/handler/http/router/mod.rs`; kept in
-/// sync by hand.
-///
-/// Every row must satisfy one of two tests: the endpoint *only reads* and uses
-/// a write method because its query lives in the body, or the endpoint is
-/// self-service maintenance of the caller's own account. Nothing else belongs
-/// here.
+/// Write-method routes a read-only account may still call. Mirrors
+/// `src/api/http/src/handler/http/router/mod.rs`; kept in sync by hand. A row
+/// belongs here only if it reads with the query in the body, or is self-service
+/// maintenance of the caller's own account.
 static READ_ONLY_ROUTES: &[ReadOnlyRoute] = &[
-    // ---- Search: the query travels in the body, nothing is persisted ----
+    // ---- Search: query travels in the body, nothing is persisted ----
     // `/{org}/_search`
     ReadOnlyRoute {
         segments: &[Param, Lit("_search")],
@@ -106,23 +82,22 @@ static READ_ONLY_ROUTES: &[ReadOnlyRoute] = &[
         segments: &[Param, Lit("_search_partition_multi")],
         method: "POST",
     },
-    // `/{org}/_search_history` — reads the caller's own past searches.
+    // `/{org}/_search_history`
     ReadOnlyRoute {
         segments: &[Param, Lit("_search_history")],
         method: "POST",
     },
-    // `/{org}/result_schema` — resolves the result schema of a query.
+    // `/{org}/result_schema`
     ReadOnlyRoute {
         segments: &[Param, Lit("result_schema")],
         method: "POST",
     },
-    // `/{org}/{stream}/_around` — the v2 (POST) form of the context view.
+    // `/{org}/{stream}/_around`
     ReadOnlyRoute {
         segments: &[Param, Param, Lit("_around")],
         method: "POST",
     },
-    // ---- PromQL: the Prometheus HTTP API offers POST forms of its read
-    // endpoints so long queries are not capped by URL length ----
+    // ---- PromQL: POST forms of read endpoints, for long queries ----
     // `/{org}/prometheus/api/v1/{query,query_range,query_exemplars,series,labels,format_query}`
     ReadOnlyRoute {
         segments: &[
@@ -185,21 +160,18 @@ static READ_ONLY_ROUTES: &[ReadOnlyRoute] = &[
         method: "POST",
     },
     // ---- Other reads that take a body ----
-    // `/v2/{org}/alerts/{alert_id}/export` — returns the alert definition the
-    // caller can already GET; the `/v2/` prefix is normalised away first.
+    // `/v2/{org}/alerts/{alert_id}/export` — returns what the caller can GET.
     ReadOnlyRoute {
         segments: &[Param, Lit("alerts"), Param, Lit("export")],
         method: "POST",
     },
-    // `/{org}/sourcemaps/stacktrace` — symbolicates a stack trace against
-    // already-stored source maps.
+    // `/{org}/sourcemaps/stacktrace` — symbolicates against stored source maps.
     ReadOnlyRoute {
         segments: &[Param, Lit("sourcemaps"), Lit("stacktrace")],
         method: "POST",
     },
     // ---- Self-service: maintaining one's own account ----
-    // `/{org}/users/{own_email}` — change own name/password. A read-only
-    // account cannot touch anyone else's user record, and the users handler
+    // `/{org}/users/{own_email}` — own name/password; the users handler
     // separately refuses self role upgrades.
     ReadOnlyRoute {
         segments: &[Param, Lit("users"), SelfEmail],
@@ -229,15 +201,9 @@ fn is_safe_method(method: &Method) -> bool {
     matches!(*method, Method::GET | Method::HEAD | Method::OPTIONS)
 }
 
-/// Does this path segment name the caller's own account?
-///
-/// Compared case-insensitively (emails are handled lowercased throughout the
-/// auth path) and, failing that, after percent-decoding: clients disagree about
-/// whether the `@` in an email is escaped inside a path segment — the frontend
-/// escapes it on the per-user settings route and leaves it raw on the users
-/// route — and the router decodes the segment either way, so this check has to
-/// accept both spellings or it would refuse a read-only account access to its
-/// own settings.
+/// Does this segment name the caller's own account? Compared case-insensitively
+/// and, failing that, percent-decoded — the frontend escapes the `@` on the
+/// settings route but not on the users route.
 fn is_self_email(segment: &str, user_email: &str) -> bool {
     if segment.is_empty() || user_email.is_empty() {
         return false;
@@ -248,16 +214,9 @@ fn is_self_email(segment: &str, user_email: &str) -> bool {
     urlencoding::decode(segment).is_ok_and(|decoded| decoded.eq_ignore_ascii_case(user_email))
 }
 
-/// May a read-only account perform this request?
-///
-/// `path` is the request path with the `/api/` and base-uri prefix already
-/// stripped, so it starts at `{org_id}`; a leading `/` and an optional `/v2/`
-/// prefix are tolerated. `user_email` is the authenticated caller's email, used
-/// only by the self-service rows.
-///
-/// Returns `true` for safe methods and for the routes declared in
-/// [`READ_ONLY_ROUTES`]; `false` for everything else, which the caller turns
-/// into a `403`.
+/// May a read-only account perform this request? `path` starts at `{org_id}`;
+/// `user_email` is the caller, used only by the self-service rows. A `false`
+/// becomes a `403`.
 pub fn is_request_allowed(method: &Method, path: &str, user_email: &str) -> bool {
     if is_safe_method(method) {
         return true;
@@ -322,7 +281,6 @@ mod tests {
     #[test]
     fn mutations_are_refused() {
         for (method, path) in [
-            // Dashboards, alerts, functions, pipelines, streams, users...
             (Method::POST, "default/dashboards"),
             (Method::PUT, "default/dashboards/abc"),
             (Method::DELETE, "default/dashboards/abc"),
@@ -342,7 +300,6 @@ mod tests {
             (Method::PUT, "default/passcode"),
             (Method::POST, "default/rumtoken"),
             (Method::POST, "default/service_accounts"),
-            // Ingestion is a write like any other.
             (Method::POST, "default/_bulk"),
             (Method::POST, "default/mystream/_json"),
             (Method::POST, "default/v1/logs"),
@@ -357,26 +314,22 @@ mod tests {
 
     #[test]
     fn self_service_is_allowed_only_for_self() {
-        // Own profile.
         assert!(is_request_allowed(
             &Method::PUT,
             &format!("default/users/{ME}"),
             ME
         ));
-        // Case differences in the path must not defeat the match.
         assert!(is_request_allowed(
             &Method::PUT,
             "default/users/Viewer@Example.com",
             ME
         ));
-        // Somebody else's profile is a privileged write.
         assert!(!is_request_allowed(
             &Method::PUT,
             "default/users/someone.else@example.com",
             ME
         ));
 
-        // Own per-user settings.
         assert!(is_request_allowed(
             &Method::POST,
             &format!("default/settings/v2/user/{ME}"),
@@ -392,9 +345,7 @@ mod tests {
             "default/settings/v2/user/someone.else@example.com",
             ME
         ));
-        // The frontend percent-encodes the email on the settings route, so the
-        // escaped spelling has to match too — otherwise a read-only account
-        // could not save its own UI preferences.
+        // The frontend percent-encodes the email on this route.
         assert!(is_request_allowed(
             &Method::POST,
             "default/settings/v2/user/viewer%40example.com",
@@ -411,7 +362,6 @@ mod tests {
             ME
         ));
 
-        // Org-level settings are not per-user settings.
         assert!(!is_request_allowed(
             &Method::POST,
             "default/settings/v2",
@@ -448,8 +398,7 @@ mod tests {
 
     #[test]
     fn a_stream_named_like_an_allowed_route_does_not_widen_access() {
-        // Matching is positional: a stream literally named `_search` lands in a
-        // `Param` slot and cannot make an ingestion route look like a search.
+        // Positional: a stream named `_search` lands in a `Param` slot.
         assert!(!is_request_allowed(
             &Method::POST,
             "default/_search/_json",

--- a/src/common/src/meta/read_only_routes.rs
+++ b/src/common/src/meta/read_only_routes.rs
@@ -41,29 +41,24 @@
 //! so segment 0 is `{org_id}`; an optional `/v2/` prefix is normalised away
 //! first, exactly like [`super::ingestion_routes`].
 
+/// `Subject` is the shared matcher's "must equal the caller-supplied subject"
+/// pattern; here the subject is always the caller's own email, so the table
+/// reads `SelfEmail`. This is what turns "update a user" into "update *my* user".
+use Seg::{Lit, Param, Subject as SelfEmail};
 use axum::http::Method;
 
-/// One segment of a declared route pattern.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Seg {
-    /// A fixed path segment that must match exactly (e.g. `_search`).
-    Lit(&'static str),
-    /// A single path parameter — matches any one non-empty segment
-    /// (`{org_id}`, `{stream_name}`, `{alert_id}`, ...).
-    Param,
-    /// A single path parameter that must equal the caller's own email. This is
-    /// what turns "update a user" into "update *my* user".
-    SelfEmail,
-}
+use super::route_match::{self, Seg};
 
-use Seg::{Lit, Param, SelfEmail};
+/// The user-facing reason a read-only account is refused. Lives here, next to
+/// the policy it describes, because both the HTTP and gRPC entry points report it.
+pub const READ_ONLY_DENIED: &str = "Read only account: this operation is not permitted";
 
 /// A route a read-only account may reach despite its write-ish HTTP method.
 struct ReadOnlyRoute {
     /// Segment patterns, starting at `{org_id}` (index 0).
     segments: &'static [Seg],
-    /// HTTP methods (as `Method::as_str()` values) this row applies to.
-    methods: &'static [&'static str],
+    /// The HTTP method (as `Method::as_str()`) this row applies to.
+    method: &'static str,
 }
 
 /// The authoritative table of write-method routes that a read-only account may
@@ -79,52 +74,52 @@ static READ_ONLY_ROUTES: &[ReadOnlyRoute] = &[
     // `/{org}/_search`
     ReadOnlyRoute {
         segments: &[Param, Lit("_search")],
-        methods: &["POST"],
+        method: "POST",
     },
     // `/{org}/_search_partition`
     ReadOnlyRoute {
         segments: &[Param, Lit("_search_partition")],
-        methods: &["POST"],
+        method: "POST",
     },
     // `/{org}/_search_stream`
     ReadOnlyRoute {
         segments: &[Param, Lit("_search_stream")],
-        methods: &["POST"],
+        method: "POST",
     },
     // `/{org}/_values_stream`
     ReadOnlyRoute {
         segments: &[Param, Lit("_values_stream")],
-        methods: &["POST"],
+        method: "POST",
     },
     // `/{org}/_search_multi`
     ReadOnlyRoute {
         segments: &[Param, Lit("_search_multi")],
-        methods: &["POST"],
+        method: "POST",
     },
     // `/{org}/_search_multi_stream`
     ReadOnlyRoute {
         segments: &[Param, Lit("_search_multi_stream")],
-        methods: &["POST"],
+        method: "POST",
     },
     // `/{org}/_search_partition_multi`
     ReadOnlyRoute {
         segments: &[Param, Lit("_search_partition_multi")],
-        methods: &["POST"],
+        method: "POST",
     },
     // `/{org}/_search_history` — reads the caller's own past searches.
     ReadOnlyRoute {
         segments: &[Param, Lit("_search_history")],
-        methods: &["POST"],
+        method: "POST",
     },
     // `/{org}/result_schema` — resolves the result schema of a query.
     ReadOnlyRoute {
         segments: &[Param, Lit("result_schema")],
-        methods: &["POST"],
+        method: "POST",
     },
     // `/{org}/{stream}/_around` — the v2 (POST) form of the context view.
     ReadOnlyRoute {
         segments: &[Param, Param, Lit("_around")],
-        methods: &["POST"],
+        method: "POST",
     },
     // ---- PromQL: the Prometheus HTTP API offers POST forms of its read
     // endpoints so long queries are not capped by URL length ----
@@ -137,7 +132,7 @@ static READ_ONLY_ROUTES: &[ReadOnlyRoute] = &[
             Lit("v1"),
             Lit("query"),
         ],
-        methods: &["POST"],
+        method: "POST",
     },
     ReadOnlyRoute {
         segments: &[
@@ -147,7 +142,7 @@ static READ_ONLY_ROUTES: &[ReadOnlyRoute] = &[
             Lit("v1"),
             Lit("query_range"),
         ],
-        methods: &["POST"],
+        method: "POST",
     },
     ReadOnlyRoute {
         segments: &[
@@ -157,7 +152,7 @@ static READ_ONLY_ROUTES: &[ReadOnlyRoute] = &[
             Lit("v1"),
             Lit("query_exemplars"),
         ],
-        methods: &["POST"],
+        method: "POST",
     },
     ReadOnlyRoute {
         segments: &[
@@ -167,7 +162,7 @@ static READ_ONLY_ROUTES: &[ReadOnlyRoute] = &[
             Lit("v1"),
             Lit("series"),
         ],
-        methods: &["POST"],
+        method: "POST",
     },
     ReadOnlyRoute {
         segments: &[
@@ -177,7 +172,7 @@ static READ_ONLY_ROUTES: &[ReadOnlyRoute] = &[
             Lit("v1"),
             Lit("labels"),
         ],
-        methods: &["POST"],
+        method: "POST",
     },
     ReadOnlyRoute {
         segments: &[
@@ -187,20 +182,20 @@ static READ_ONLY_ROUTES: &[ReadOnlyRoute] = &[
             Lit("v1"),
             Lit("format_query"),
         ],
-        methods: &["POST"],
+        method: "POST",
     },
     // ---- Other reads that take a body ----
     // `/v2/{org}/alerts/{alert_id}/export` — returns the alert definition the
     // caller can already GET; the `/v2/` prefix is normalised away first.
     ReadOnlyRoute {
         segments: &[Param, Lit("alerts"), Param, Lit("export")],
-        methods: &["POST"],
+        method: "POST",
     },
     // `/{org}/sourcemaps/stacktrace` — symbolicates a stack trace against
     // already-stored source maps.
     ReadOnlyRoute {
         segments: &[Param, Lit("sourcemaps"), Lit("stacktrace")],
-        methods: &["POST"],
+        method: "POST",
     },
     // ---- Self-service: maintaining one's own account ----
     // `/{org}/users/{own_email}` — change own name/password. A read-only
@@ -208,12 +203,12 @@ static READ_ONLY_ROUTES: &[ReadOnlyRoute] = &[
     // separately refuses self role upgrades.
     ReadOnlyRoute {
         segments: &[Param, Lit("users"), SelfEmail],
-        methods: &["PUT"],
+        method: "PUT",
     },
     // `/{org}/settings/v2/user/{own_email}` — own UI preferences.
     ReadOnlyRoute {
         segments: &[Param, Lit("settings"), Lit("v2"), Lit("user"), SelfEmail],
-        methods: &["POST"],
+        method: "POST",
     },
     // `/{org}/settings/v2/user/{own_email}/{key}` — drop one own preference.
     ReadOnlyRoute {
@@ -225,29 +220,13 @@ static READ_ONLY_ROUTES: &[ReadOnlyRoute] = &[
             SelfEmail,
             Param,
         ],
-        methods: &["DELETE"],
+        method: "DELETE",
     },
 ];
-
-/// The `/v2/...` API prefix, stripped before matching so `/v2/{org}/alerts/...`
-/// classifies identically to `/{org}/alerts/...`.
-const V2_API_PREFIX: &str = "v2";
 
 /// HTTP methods that cannot mutate state and are therefore always allowed.
 fn is_safe_method(method: &Method) -> bool {
     matches!(*method, Method::GET | Method::HEAD | Method::OPTIONS)
-}
-
-/// Does this segment pattern list match these path segments?
-fn segments_match(patterns: &[Seg], columns: &[&str], user_email: &str) -> bool {
-    if patterns.len() != columns.len() {
-        return false;
-    }
-    patterns.iter().zip(columns).all(|(pat, col)| match pat {
-        Seg::Lit(lit) => col == lit,
-        Seg::Param => !col.is_empty(),
-        Seg::SelfEmail => is_self_email(col, user_email),
-    })
 }
 
 /// Does this path segment name the caller's own account?
@@ -284,24 +263,15 @@ pub fn is_request_allowed(method: &Method, path: &str, user_email: &str) -> bool
         return true;
     }
 
-    let path = path.strip_prefix('/').unwrap_or(path);
-    // Normalise the optional `/v2/{org}/...` prefix to `/{org}/...`.
-    let path = path
-        .strip_prefix(V2_API_PREFIX)
-        .and_then(|rest| rest.strip_prefix('/'))
-        .unwrap_or(path);
-
+    let path = route_match::strip_api_prefixes(path);
     let method = method.as_str();
-
-    // A single trailing empty segment (trailing slash) is dropped so
-    // `.../_search/` == `.../_search`.
-    let mut columns: Vec<&str> = path.split('/').collect();
-    if columns.len() > 1 && columns.last() == Some(&"") {
-        columns.pop();
-    }
+    let columns = route_match::columns(path);
 
     READ_ONLY_ROUTES.iter().any(|route| {
-        route.methods.contains(&method) && segments_match(route.segments, &columns, user_email)
+        route.method == method
+            && route_match::segments_match(route.segments, &columns, |col| {
+                is_self_email(col, user_email)
+            })
     })
 }
 

--- a/src/common/src/meta/read_only_routes.rs
+++ b/src/common/src/meta/read_only_routes.rs
@@ -1,0 +1,494 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! What a **read only account** is allowed to do.
+//!
+//! Enterprise builds answer this question with OpenFGA: every route carries a
+//! declared permission and the authorization model decides. OSS builds have no
+//! FGA, so `Viewer` (and the system-managed `SreAgent`) would otherwise be
+//! indistinguishable from `Admin` once authenticated. This module is the OSS
+//! answer — a single, declarative source of truth that the auth layer consults
+//! for every authenticated request made by a read-only account.
+//!
+//! The rule is deliberately narrow, so that "read only" means exactly that:
+//!
+//! 1. **Safe HTTP methods pass.** `GET`, `HEAD` and `OPTIONS` never mutate.
+//! 2. **A short allowlist of query-by-POST routes passes.** Search and PromQL-style endpoints use
+//!    `POST` only because the query travels in the request body; they persist nothing. Each row in
+//!    [`READ_ONLY_ROUTES`] is an endpoint of that kind and nothing else — no "test", "preview" or
+//!    "create" endpoints, however harmless they look.
+//! 3. **A read-only account may maintain its own account.** Updating one's own profile/password and
+//!    one's own per-user UI settings is self-service, not a privileged write, so it is allowed when
+//!    the email in the path is the caller's own.
+//!
+//! Everything else — every other `POST`/`PUT`/`PATCH`/`DELETE`, including all
+//! ingestion — is refused. Adding a new read-only endpoint that uses a write
+//! method means adding a row here and nothing else.
+//!
+//! Paths are matched with the `/api/` (and base-uri) prefix already stripped,
+//! so segment 0 is `{org_id}`; an optional `/v2/` prefix is normalised away
+//! first, exactly like [`super::ingestion_routes`].
+
+use axum::http::Method;
+
+/// One segment of a declared route pattern.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Seg {
+    /// A fixed path segment that must match exactly (e.g. `_search`).
+    Lit(&'static str),
+    /// A single path parameter — matches any one non-empty segment
+    /// (`{org_id}`, `{stream_name}`, `{alert_id}`, ...).
+    Param,
+    /// A single path parameter that must equal the caller's own email. This is
+    /// what turns "update a user" into "update *my* user".
+    SelfEmail,
+}
+
+use Seg::{Lit, Param, SelfEmail};
+
+/// A route a read-only account may reach despite its write-ish HTTP method.
+struct ReadOnlyRoute {
+    /// Segment patterns, starting at `{org_id}` (index 0).
+    segments: &'static [Seg],
+    /// HTTP methods (as `Method::as_str()` values) this row applies to.
+    methods: &'static [&'static str],
+}
+
+/// The authoritative table of write-method routes that a read-only account may
+/// still call. Mirrors `src/api/http/src/handler/http/router/mod.rs`; kept in
+/// sync by hand.
+///
+/// Every row must satisfy one of two tests: the endpoint *only reads* and uses
+/// a write method because its query lives in the body, or the endpoint is
+/// self-service maintenance of the caller's own account. Nothing else belongs
+/// here.
+static READ_ONLY_ROUTES: &[ReadOnlyRoute] = &[
+    // ---- Search: the query travels in the body, nothing is persisted ----
+    // `/{org}/_search`
+    ReadOnlyRoute {
+        segments: &[Param, Lit("_search")],
+        methods: &["POST"],
+    },
+    // `/{org}/_search_partition`
+    ReadOnlyRoute {
+        segments: &[Param, Lit("_search_partition")],
+        methods: &["POST"],
+    },
+    // `/{org}/_search_stream`
+    ReadOnlyRoute {
+        segments: &[Param, Lit("_search_stream")],
+        methods: &["POST"],
+    },
+    // `/{org}/_values_stream`
+    ReadOnlyRoute {
+        segments: &[Param, Lit("_values_stream")],
+        methods: &["POST"],
+    },
+    // `/{org}/_search_multi`
+    ReadOnlyRoute {
+        segments: &[Param, Lit("_search_multi")],
+        methods: &["POST"],
+    },
+    // `/{org}/_search_multi_stream`
+    ReadOnlyRoute {
+        segments: &[Param, Lit("_search_multi_stream")],
+        methods: &["POST"],
+    },
+    // `/{org}/_search_partition_multi`
+    ReadOnlyRoute {
+        segments: &[Param, Lit("_search_partition_multi")],
+        methods: &["POST"],
+    },
+    // `/{org}/_search_history` — reads the caller's own past searches.
+    ReadOnlyRoute {
+        segments: &[Param, Lit("_search_history")],
+        methods: &["POST"],
+    },
+    // `/{org}/result_schema` — resolves the result schema of a query.
+    ReadOnlyRoute {
+        segments: &[Param, Lit("result_schema")],
+        methods: &["POST"],
+    },
+    // `/{org}/{stream}/_around` — the v2 (POST) form of the context view.
+    ReadOnlyRoute {
+        segments: &[Param, Param, Lit("_around")],
+        methods: &["POST"],
+    },
+    // ---- PromQL: the Prometheus HTTP API offers POST forms of its read
+    // endpoints so long queries are not capped by URL length ----
+    // `/{org}/prometheus/api/v1/{query,query_range,query_exemplars,series,labels,format_query}`
+    ReadOnlyRoute {
+        segments: &[
+            Param,
+            Lit("prometheus"),
+            Lit("api"),
+            Lit("v1"),
+            Lit("query"),
+        ],
+        methods: &["POST"],
+    },
+    ReadOnlyRoute {
+        segments: &[
+            Param,
+            Lit("prometheus"),
+            Lit("api"),
+            Lit("v1"),
+            Lit("query_range"),
+        ],
+        methods: &["POST"],
+    },
+    ReadOnlyRoute {
+        segments: &[
+            Param,
+            Lit("prometheus"),
+            Lit("api"),
+            Lit("v1"),
+            Lit("query_exemplars"),
+        ],
+        methods: &["POST"],
+    },
+    ReadOnlyRoute {
+        segments: &[
+            Param,
+            Lit("prometheus"),
+            Lit("api"),
+            Lit("v1"),
+            Lit("series"),
+        ],
+        methods: &["POST"],
+    },
+    ReadOnlyRoute {
+        segments: &[
+            Param,
+            Lit("prometheus"),
+            Lit("api"),
+            Lit("v1"),
+            Lit("labels"),
+        ],
+        methods: &["POST"],
+    },
+    ReadOnlyRoute {
+        segments: &[
+            Param,
+            Lit("prometheus"),
+            Lit("api"),
+            Lit("v1"),
+            Lit("format_query"),
+        ],
+        methods: &["POST"],
+    },
+    // ---- Other reads that take a body ----
+    // `/v2/{org}/alerts/{alert_id}/export` — returns the alert definition the
+    // caller can already GET; the `/v2/` prefix is normalised away first.
+    ReadOnlyRoute {
+        segments: &[Param, Lit("alerts"), Param, Lit("export")],
+        methods: &["POST"],
+    },
+    // `/{org}/sourcemaps/stacktrace` — symbolicates a stack trace against
+    // already-stored source maps.
+    ReadOnlyRoute {
+        segments: &[Param, Lit("sourcemaps"), Lit("stacktrace")],
+        methods: &["POST"],
+    },
+    // ---- Self-service: maintaining one's own account ----
+    // `/{org}/users/{own_email}` — change own name/password. A read-only
+    // account cannot touch anyone else's user record, and the users handler
+    // separately refuses self role upgrades.
+    ReadOnlyRoute {
+        segments: &[Param, Lit("users"), SelfEmail],
+        methods: &["PUT"],
+    },
+    // `/{org}/settings/v2/user/{own_email}` — own UI preferences.
+    ReadOnlyRoute {
+        segments: &[Param, Lit("settings"), Lit("v2"), Lit("user"), SelfEmail],
+        methods: &["POST"],
+    },
+    // `/{org}/settings/v2/user/{own_email}/{key}` — drop one own preference.
+    ReadOnlyRoute {
+        segments: &[
+            Param,
+            Lit("settings"),
+            Lit("v2"),
+            Lit("user"),
+            SelfEmail,
+            Param,
+        ],
+        methods: &["DELETE"],
+    },
+];
+
+/// The `/v2/...` API prefix, stripped before matching so `/v2/{org}/alerts/...`
+/// classifies identically to `/{org}/alerts/...`.
+const V2_API_PREFIX: &str = "v2";
+
+/// HTTP methods that cannot mutate state and are therefore always allowed.
+fn is_safe_method(method: &Method) -> bool {
+    matches!(*method, Method::GET | Method::HEAD | Method::OPTIONS)
+}
+
+/// Does this segment pattern list match these path segments?
+fn segments_match(patterns: &[Seg], columns: &[&str], user_email: &str) -> bool {
+    if patterns.len() != columns.len() {
+        return false;
+    }
+    patterns.iter().zip(columns).all(|(pat, col)| match pat {
+        Seg::Lit(lit) => col == lit,
+        Seg::Param => !col.is_empty(),
+        Seg::SelfEmail => is_self_email(col, user_email),
+    })
+}
+
+/// Does this path segment name the caller's own account?
+///
+/// Compared case-insensitively (emails are handled lowercased throughout the
+/// auth path) and, failing that, after percent-decoding: clients disagree about
+/// whether the `@` in an email is escaped inside a path segment — the frontend
+/// escapes it on the per-user settings route and leaves it raw on the users
+/// route — and the router decodes the segment either way, so this check has to
+/// accept both spellings or it would refuse a read-only account access to its
+/// own settings.
+fn is_self_email(segment: &str, user_email: &str) -> bool {
+    if segment.is_empty() || user_email.is_empty() {
+        return false;
+    }
+    if segment.eq_ignore_ascii_case(user_email) {
+        return true;
+    }
+    urlencoding::decode(segment).is_ok_and(|decoded| decoded.eq_ignore_ascii_case(user_email))
+}
+
+/// May a read-only account perform this request?
+///
+/// `path` is the request path with the `/api/` and base-uri prefix already
+/// stripped, so it starts at `{org_id}`; a leading `/` and an optional `/v2/`
+/// prefix are tolerated. `user_email` is the authenticated caller's email, used
+/// only by the self-service rows.
+///
+/// Returns `true` for safe methods and for the routes declared in
+/// [`READ_ONLY_ROUTES`]; `false` for everything else, which the caller turns
+/// into a `403`.
+pub fn is_request_allowed(method: &Method, path: &str, user_email: &str) -> bool {
+    if is_safe_method(method) {
+        return true;
+    }
+
+    let path = path.strip_prefix('/').unwrap_or(path);
+    // Normalise the optional `/v2/{org}/...` prefix to `/{org}/...`.
+    let path = path
+        .strip_prefix(V2_API_PREFIX)
+        .and_then(|rest| rest.strip_prefix('/'))
+        .unwrap_or(path);
+
+    let method = method.as_str();
+
+    // A single trailing empty segment (trailing slash) is dropped so
+    // `.../_search/` == `.../_search`.
+    let mut columns: Vec<&str> = path.split('/').collect();
+    if columns.len() > 1 && columns.last() == Some(&"") {
+        columns.pop();
+    }
+
+    READ_ONLY_ROUTES.iter().any(|route| {
+        route.methods.contains(&method) && segments_match(route.segments, &columns, user_email)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ME: &str = "viewer@example.com";
+
+    #[test]
+    fn safe_methods_are_always_allowed() {
+        for method in [Method::GET, Method::HEAD, Method::OPTIONS] {
+            assert!(is_request_allowed(&method, "default/dashboards", ME));
+            assert!(is_request_allowed(&method, "default/users", ME));
+            assert!(is_request_allowed(&method, "anything/at/all", ME));
+        }
+    }
+
+    #[test]
+    fn search_posts_are_allowed() {
+        for path in [
+            "default/_search",
+            "default/_search_partition",
+            "default/_search_stream",
+            "default/_values_stream",
+            "default/_search_multi",
+            "default/_search_multi_stream",
+            "default/_search_partition_multi",
+            "default/_search_history",
+            "default/result_schema",
+            "default/mystream/_around",
+            "default/prometheus/api/v1/query",
+            "default/prometheus/api/v1/query_range",
+            "default/prometheus/api/v1/query_exemplars",
+            "default/prometheus/api/v1/series",
+            "default/prometheus/api/v1/labels",
+            "default/prometheus/api/v1/format_query",
+            "default/alerts/2Abc/export",
+            "default/sourcemaps/stacktrace",
+        ] {
+            assert!(
+                is_request_allowed(&Method::POST, path, ME),
+                "expected POST /{path} to be allowed"
+            );
+        }
+    }
+
+    #[test]
+    fn mutations_are_refused() {
+        for (method, path) in [
+            // Dashboards, alerts, functions, pipelines, streams, users...
+            (Method::POST, "default/dashboards"),
+            (Method::PUT, "default/dashboards/abc"),
+            (Method::DELETE, "default/dashboards/abc"),
+            (Method::PATCH, "default/dashboards/move"),
+            (Method::POST, "default/users"),
+            (Method::DELETE, "default/users/someone@example.com"),
+            (Method::POST, "default/functions"),
+            (Method::POST, "default/streams/mystream"),
+            (Method::PUT, "default/streams/mystream/settings"),
+            (Method::POST, "default/alerts/templates"),
+            (Method::POST, "default/alerts/destinations/test"),
+            (Method::POST, "default/functions/test"),
+            (Method::POST, "default/alerts/templates/preview"),
+            (Method::POST, "default/short"),
+            (Method::POST, "default/mcp"),
+            (Method::POST, "default/settings"),
+            (Method::PUT, "default/passcode"),
+            (Method::POST, "default/rumtoken"),
+            (Method::POST, "default/service_accounts"),
+            // Ingestion is a write like any other.
+            (Method::POST, "default/_bulk"),
+            (Method::POST, "default/mystream/_json"),
+            (Method::POST, "default/v1/logs"),
+            (Method::POST, "default/prometheus/api/v1/write"),
+        ] {
+            assert!(
+                !is_request_allowed(&method, path, ME),
+                "expected {method} /{path} to be refused"
+            );
+        }
+    }
+
+    #[test]
+    fn self_service_is_allowed_only_for_self() {
+        // Own profile.
+        assert!(is_request_allowed(
+            &Method::PUT,
+            &format!("default/users/{ME}"),
+            ME
+        ));
+        // Case differences in the path must not defeat the match.
+        assert!(is_request_allowed(
+            &Method::PUT,
+            "default/users/Viewer@Example.com",
+            ME
+        ));
+        // Somebody else's profile is a privileged write.
+        assert!(!is_request_allowed(
+            &Method::PUT,
+            "default/users/someone.else@example.com",
+            ME
+        ));
+
+        // Own per-user settings.
+        assert!(is_request_allowed(
+            &Method::POST,
+            &format!("default/settings/v2/user/{ME}"),
+            ME
+        ));
+        assert!(is_request_allowed(
+            &Method::DELETE,
+            &format!("default/settings/v2/user/{ME}/theme"),
+            ME
+        ));
+        assert!(!is_request_allowed(
+            &Method::POST,
+            "default/settings/v2/user/someone.else@example.com",
+            ME
+        ));
+        // The frontend percent-encodes the email on the settings route, so the
+        // escaped spelling has to match too — otherwise a read-only account
+        // could not save its own UI preferences.
+        assert!(is_request_allowed(
+            &Method::POST,
+            "default/settings/v2/user/viewer%40example.com",
+            ME
+        ));
+        assert!(is_request_allowed(
+            &Method::PUT,
+            "default/users/viewer%40example.com",
+            ME
+        ));
+        assert!(!is_request_allowed(
+            &Method::POST,
+            "default/settings/v2/user/someone.else%40example.com",
+            ME
+        ));
+
+        // Org-level settings are not per-user settings.
+        assert!(!is_request_allowed(
+            &Method::POST,
+            "default/settings/v2",
+            ME
+        ));
+        assert!(!is_request_allowed(
+            &Method::DELETE,
+            "default/settings/v2/theme",
+            ME
+        ));
+    }
+
+    #[test]
+    fn v2_prefix_is_normalised() {
+        assert!(is_request_allowed(
+            &Method::POST,
+            "v2/default/alerts/2Abc/export",
+            ME
+        ));
+        assert!(is_request_allowed(&Method::POST, "v2/default/_search", ME));
+        assert!(!is_request_allowed(&Method::POST, "v2/default/alerts", ME));
+    }
+
+    #[test]
+    fn leading_slash_and_trailing_slash_are_tolerated() {
+        assert!(is_request_allowed(&Method::POST, "/default/_search", ME));
+        assert!(is_request_allowed(&Method::POST, "default/_search/", ME));
+        assert!(!is_request_allowed(
+            &Method::POST,
+            "/default/dashboards",
+            ME
+        ));
+    }
+
+    #[test]
+    fn a_stream_named_like_an_allowed_route_does_not_widen_access() {
+        // Matching is positional: a stream literally named `_search` lands in a
+        // `Param` slot and cannot make an ingestion route look like a search.
+        assert!(!is_request_allowed(
+            &Method::POST,
+            "default/_search/_json",
+            ME
+        ));
+        assert!(!is_request_allowed(
+            &Method::POST,
+            "default/users/_search",
+            ME
+        ));
+    }
+}

--- a/src/common/src/meta/route_match.rs
+++ b/src/common/src/meta/route_match.rs
@@ -1,0 +1,139 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Positional route matching, shared by the declarative route tables in this
+//! module ([`super::ingestion_routes`] and [`super::read_only_routes`]).
+//!
+//! Both tables answer an authorization question by matching a request against
+//! declared `(path shape, methods)` rows, and both must normalise the request
+//! path the same way to be sound. Historically the auth layer matched paths by
+//! substring — which is what let an ingestion token read protected data on
+//! `GET /{org}/{stream}/traces/latest`, GHSA-wffq-g8qf-ccmv. Matching here is
+//! *positional* instead: a stream literally named `traces` only ever lands in a
+//! [`Seg::Param`] slot and can never be mistaken for the `traces` keyword.
+//!
+//! Keeping the matcher in one place is deliberate: two copies of these
+//! normalisation rules would drift, and a fix applied to one table would
+//! silently miss the other.
+
+/// One segment of a declared route pattern.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Seg {
+    /// A fixed path segment that must match exactly (e.g. `_bulk`, `traces`).
+    Lit(&'static str),
+    /// A single path parameter — matches any one non-empty segment
+    /// (`{org_id}`, `{stream_name}`, `{name}`, ...). It deliberately does NOT
+    /// match a keyword by accident because matching is positional.
+    Param,
+    /// A single path parameter constrained to the caller-supplied *subject*
+    /// (see `subject_matches` on [`segments_match`]) — e.g. "this must be the
+    /// caller's own account". A table that supplies no subject predicate can
+    /// never match this pattern, so it fails closed.
+    Subject,
+}
+
+/// The `/v2/...` API prefix, stripped before matching so `/v2/{org}/_bulk`
+/// classifies identically to `/{org}/_bulk`.
+const V2_API_PREFIX: &str = "v2";
+
+/// Strip the leading `/` and an optional `/v2/` prefix, leaving a path that
+/// starts at `{org_id}`.
+///
+/// Returned as a `&str` rather than pre-split segments so callers that need to
+/// distinguish a trailing slash (e.g. the Elasticsearch root ping `GET /{org}/`)
+/// can still see it.
+pub(crate) fn strip_api_prefixes(path: &str) -> &str {
+    let path = path.strip_prefix('/').unwrap_or(path);
+    path.strip_prefix(V2_API_PREFIX)
+        .and_then(|rest| rest.strip_prefix('/'))
+        .unwrap_or(path)
+}
+
+/// Split a prefix-stripped path into the segments used for matching.
+///
+/// A single trailing empty segment (trailing slash) is dropped, so
+/// `.../_bulk/` matches the same row as `.../_bulk`.
+pub(crate) fn columns(path: &str) -> Vec<&str> {
+    path.strip_suffix('/').unwrap_or(path).split('/').collect()
+}
+
+/// Does this segment pattern list match these path segments?
+///
+/// `subject_matches` decides [`Seg::Subject`] segments; pass `|_| false` from
+/// tables that declare no subject-constrained routes.
+pub(crate) fn segments_match(
+    patterns: &[Seg],
+    columns: &[&str],
+    subject_matches: impl Fn(&str) -> bool,
+) -> bool {
+    if patterns.len() != columns.len() {
+        return false;
+    }
+    patterns.iter().zip(columns).all(|(pat, col)| match pat {
+        Seg::Lit(lit) => col == lit,
+        // A param matches any single non-empty segment.
+        Seg::Param => !col.is_empty(),
+        Seg::Subject => subject_matches(col),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Seg::*, *};
+
+    #[test]
+    fn strips_leading_slash_and_v2_prefix() {
+        assert_eq!(strip_api_prefixes("default/_bulk"), "default/_bulk");
+        assert_eq!(strip_api_prefixes("/default/_bulk"), "default/_bulk");
+        assert_eq!(strip_api_prefixes("/v2/default/_bulk"), "default/_bulk");
+        // `v2` as an org name is not a prefix — it has no following slash to
+        // strip beyond its own, so the org survives.
+        assert_eq!(strip_api_prefixes("/v2suffix/_bulk"), "v2suffix/_bulk");
+    }
+
+    #[test]
+    fn drops_a_single_trailing_empty_segment() {
+        assert_eq!(columns("a/b"), vec!["a", "b"]);
+        assert_eq!(columns("a/b/"), vec!["a", "b"]);
+        assert_eq!(columns("a//"), vec!["a", ""]);
+        assert_eq!(columns(""), vec![""]);
+    }
+
+    #[test]
+    fn matching_is_positional_and_length_exact() {
+        let pattern = &[Param, Lit("traces"), Lit("latest")];
+        assert!(segments_match(
+            pattern,
+            &["default", "traces", "latest"],
+            |_| false
+        ));
+        // A stream *named* `traces` cannot impersonate the keyword slot.
+        assert!(!segments_match(pattern, &["default", "traces"], |_| false));
+        assert!(!segments_match(
+            pattern,
+            &["default", "traces", "latest", "extra"],
+            |_| false
+        ));
+        // A param never matches an empty segment.
+        assert!(!segments_match(&[Param], &[""], |_| false));
+    }
+
+    #[test]
+    fn subject_segments_fail_closed_without_a_predicate() {
+        assert!(!segments_match(&[Subject], &["me@example.com"], |_| false));
+        assert!(segments_match(&[Subject], &["me@example.com"], |col| col
+            == "me@example.com"));
+    }
+}

--- a/src/common/src/meta/route_match.rs
+++ b/src/common/src/meta/route_match.rs
@@ -50,6 +50,20 @@ pub(crate) fn columns(path: &str) -> Vec<&str> {
     path.strip_suffix('/').unwrap_or(path).split('/').collect()
 }
 
+/// Segment lists to try for `path`. Usually one, but `/v2/_search` is genuinely
+/// ambiguous — the `/v2/` API prefix on org `_search`, or an org literally named
+/// `v2`, which nothing reserves — so both readings are offered. A row matches if
+/// either does.
+pub(crate) fn candidate_columns(path: &str) -> Vec<Vec<&str>> {
+    let unprefixed = path.strip_prefix('/').unwrap_or(path);
+    let stripped = strip_api_prefixes(path);
+    let mut candidates = vec![columns(stripped)];
+    if stripped != unprefixed {
+        candidates.push(columns(unprefixed));
+    }
+    candidates
+}
+
 /// `subject_matches` decides [`Seg::Subject`] segments; pass `|_| false` from
 /// tables with no subject-constrained routes.
 pub(crate) fn segments_match(
@@ -78,6 +92,24 @@ mod tests {
         assert_eq!(strip_api_prefixes("/v2/default/_bulk"), "default/_bulk");
         // `v2` as an org name is not a prefix.
         assert_eq!(strip_api_prefixes("/v2suffix/_bulk"), "v2suffix/_bulk");
+    }
+
+    /// An org may be literally named `v2`, so `/v2/_search` has to be offered
+    /// both as the versioned prefix and as that org's unversioned route.
+    #[test]
+    fn offers_both_readings_of_a_v2_prefix() {
+        assert_eq!(
+            candidate_columns("/default/_search"),
+            vec![vec!["default", "_search"]]
+        );
+        assert_eq!(
+            candidate_columns("/v2/_search"),
+            vec![vec!["_search"], vec!["v2", "_search"]]
+        );
+        assert_eq!(
+            candidate_columns("/v2/default/_search"),
+            vec![vec!["default", "_search"], vec!["v2", "default", "_search"]]
+        );
     }
 
     #[test]

--- a/src/common/src/meta/route_match.rs
+++ b/src/common/src/meta/route_match.rs
@@ -13,47 +13,31 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Positional route matching, shared by the declarative route tables in this
-//! module ([`super::ingestion_routes`] and [`super::read_only_routes`]).
+//! Positional route matching, shared by [`super::ingestion_routes`] and
+//! [`super::read_only_routes`] so their normalisation rules cannot drift.
 //!
-//! Both tables answer an authorization question by matching a request against
-//! declared `(path shape, methods)` rows, and both must normalise the request
-//! path the same way to be sound. Historically the auth layer matched paths by
-//! substring — which is what let an ingestion token read protected data on
-//! `GET /{org}/{stream}/traces/latest`, GHSA-wffq-g8qf-ccmv. Matching here is
-//! *positional* instead: a stream literally named `traces` only ever lands in a
-//! [`Seg::Param`] slot and can never be mistaken for the `traces` keyword.
-//!
-//! Keeping the matcher in one place is deliberate: two copies of these
-//! normalisation rules would drift, and a fix applied to one table would
-//! silently miss the other.
+//! Positional rather than substring matching: substring matching is what let an
+//! ingestion token read `GET /{org}/{stream}/traces/latest` (GHSA-wffq-g8qf-ccmv).
+//! A stream named `traces` only ever lands in a [`Seg::Param`] slot.
 
 /// One segment of a declared route pattern.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Seg {
     /// A fixed path segment that must match exactly (e.g. `_bulk`, `traces`).
     Lit(&'static str),
-    /// A single path parameter — matches any one non-empty segment
-    /// (`{org_id}`, `{stream_name}`, `{name}`, ...). It deliberately does NOT
-    /// match a keyword by accident because matching is positional.
+    /// Any one non-empty segment (`{org_id}`, `{stream_name}`, ...).
     Param,
-    /// A single path parameter constrained to the caller-supplied *subject*
-    /// (see `subject_matches` on [`segments_match`]) — e.g. "this must be the
-    /// caller's own account". A table that supplies no subject predicate can
-    /// never match this pattern, so it fails closed.
+    /// A segment constrained to the caller-supplied subject (see
+    /// `subject_matches` on [`segments_match`]). Fails closed without one.
     Subject,
 }
 
-/// The `/v2/...` API prefix, stripped before matching so `/v2/{org}/_bulk`
-/// classifies identically to `/{org}/_bulk`.
+/// Stripped before matching, so `/v2/{org}/_bulk` matches `/{org}/_bulk`.
 const V2_API_PREFIX: &str = "v2";
 
-/// Strip the leading `/` and an optional `/v2/` prefix, leaving a path that
-/// starts at `{org_id}`.
-///
-/// Returned as a `&str` rather than pre-split segments so callers that need to
-/// distinguish a trailing slash (e.g. the Elasticsearch root ping `GET /{org}/`)
-/// can still see it.
+/// Strip the leading `/` and any `/v2/` prefix, leaving a path at `{org_id}`.
+/// Returns a `&str` so callers can still see a trailing slash (e.g. the
+/// Elasticsearch root ping `GET /{org}/`).
 pub(crate) fn strip_api_prefixes(path: &str) -> &str {
     let path = path.strip_prefix('/').unwrap_or(path);
     path.strip_prefix(V2_API_PREFIX)
@@ -61,18 +45,13 @@ pub(crate) fn strip_api_prefixes(path: &str) -> &str {
         .unwrap_or(path)
 }
 
-/// Split a prefix-stripped path into the segments used for matching.
-///
-/// A single trailing empty segment (trailing slash) is dropped, so
-/// `.../_bulk/` matches the same row as `.../_bulk`.
+/// Split a prefix-stripped path for matching, dropping one trailing slash.
 pub(crate) fn columns(path: &str) -> Vec<&str> {
     path.strip_suffix('/').unwrap_or(path).split('/').collect()
 }
 
-/// Does this segment pattern list match these path segments?
-///
 /// `subject_matches` decides [`Seg::Subject`] segments; pass `|_| false` from
-/// tables that declare no subject-constrained routes.
+/// tables with no subject-constrained routes.
 pub(crate) fn segments_match(
     patterns: &[Seg],
     columns: &[&str],
@@ -83,7 +62,6 @@ pub(crate) fn segments_match(
     }
     patterns.iter().zip(columns).all(|(pat, col)| match pat {
         Seg::Lit(lit) => col == lit,
-        // A param matches any single non-empty segment.
         Seg::Param => !col.is_empty(),
         Seg::Subject => subject_matches(col),
     })
@@ -98,8 +76,7 @@ mod tests {
         assert_eq!(strip_api_prefixes("default/_bulk"), "default/_bulk");
         assert_eq!(strip_api_prefixes("/default/_bulk"), "default/_bulk");
         assert_eq!(strip_api_prefixes("/v2/default/_bulk"), "default/_bulk");
-        // `v2` as an org name is not a prefix — it has no following slash to
-        // strip beyond its own, so the org survives.
+        // `v2` as an org name is not a prefix.
         assert_eq!(strip_api_prefixes("/v2suffix/_bulk"), "v2suffix/_bulk");
     }
 
@@ -119,14 +96,12 @@ mod tests {
             &["default", "traces", "latest"],
             |_| false
         ));
-        // A stream *named* `traces` cannot impersonate the keyword slot.
         assert!(!segments_match(pattern, &["default", "traces"], |_| false));
         assert!(!segments_match(
             pattern,
             &["default", "traces", "latest", "extra"],
             |_| false
         ));
-        // A param never matches an empty segment.
         assert!(!segments_match(&[Param], &[""], |_| false));
     }
 

--- a/src/common/src/meta/user.rs
+++ b/src/common/src/meta/user.rs
@@ -174,13 +174,9 @@ pub fn get_roles() -> Vec<UserRole> {
     UserRole::iter().collect()
 }
 
-/// Roles an OSS deployment understands.
-///
-/// OSS has no OpenFGA, so the fine-grained roles (`Editor`, `User`, custom
-/// roles) are not offered — there is nothing to enforce them with. `Viewer` is
-/// the exception: it is a whole-org "read only" account, which the auth layer
-/// enforces on its own via the read-only route policy, so it is available in
-/// OSS as well.
+/// Roles an OSS deployment understands. The fine-grained roles need an
+/// authorization model OSS lacks; `Viewer` is offered because the auth layer
+/// enforces it through the read-only route policy.
 #[cfg(not(feature = "enterprise"))]
 pub fn get_roles() -> Vec<UserRole> {
     vec![
@@ -191,17 +187,9 @@ pub fn get_roles() -> Vec<UserRole> {
     ]
 }
 
-/// Collapse a *requested* role to what an OSS deployment can actually enforce.
-///
-/// This is the single rule behind every OSS role assignment. `Viewer` is
-/// honoured — the auth layer enforces it by itself through the read-only route
-/// policy — and everything else collapses to `Admin`, which is the
-/// long-standing OSS behaviour for roles it has no enforcement for.
-///
-/// Note what this deliberately does *not* do: it never elevates. A request
-/// asking for `Root` gets `Admin`, so the user-management endpoints cannot be
-/// used to mint a privileged account. Service accounts are unaffected because
-/// they are created through their own endpoint, which sets the role directly.
+/// Collapse a requested role to what OSS can enforce: `Viewer` is honoured,
+/// everything else becomes `Admin`. Never elevates — a request for `Root` gets
+/// `Admin`, so this path cannot mint a privileged account.
 #[cfg(not(feature = "enterprise"))]
 pub fn get_supported_role(requested: &UserRole) -> UserRole {
     if requested == &UserRole::Viewer {
@@ -513,8 +501,7 @@ mod tests {
 
     use super::*;
 
-    /// The read-only Viewer is assignable in OSS; the fine-grained roles, which
-    /// OSS has no enforcement for, are not offered.
+    /// Viewer is assignable in OSS; the fine-grained roles are not.
     #[cfg(not(feature = "enterprise"))]
     #[test]
     fn test_oss_roles_include_viewer() {
@@ -525,14 +512,12 @@ mod tests {
         assert!(!roles.contains(&UserRole::User));
     }
 
-    /// `get_roles` (what OSS knows about) and `get_supported_role` (what OSS
-    /// will actually assign) must not drift apart, or a role reachable through
-    /// the API gets silently rewritten on save. Every listed role has to fall
-    /// into one of the two groups below, so adding one forces that decision.
+    /// `get_roles` and `get_supported_role` must not drift, or a role reachable
+    /// through the API gets silently rewritten on save.
     #[cfg(not(feature = "enterprise"))]
     #[test]
     fn test_offered_roles_are_assignable() {
-        // Assignable through the users API, and preserved as asked.
+        // Assignable through the users API, preserved as asked.
         for role in [UserRole::Admin, UserRole::Viewer] {
             assert_eq!(
                 get_supported_role(&role),
@@ -540,17 +525,14 @@ mod tests {
                 "OSS offers {role} but would assign something else"
             );
         }
-        // Listed so existing accounts resolve, but never assignable through the
-        // users API: Root must not be mintable, and a service account gets its
-        // role from the service-account endpoints, not this path.
+        // Resolve for existing accounts, but never assignable here.
         for role in [UserRole::Root, UserRole::ServiceAccount] {
             assert_eq!(get_supported_role(&role), UserRole::Admin);
         }
         assert_eq!(get_roles().len(), 4, "a new OSS role needs a group above");
     }
 
-    /// A role request resolves to Viewer or Admin and nothing else — in
-    /// particular a request for Root must not elevate.
+    /// A role request resolves to Viewer or Admin and nothing else.
     #[cfg(not(feature = "enterprise"))]
     #[test]
     fn test_get_supported_role() {
@@ -567,9 +549,8 @@ mod tests {
         }
     }
 
-    /// The role a client asks for on the wire ("viewer") has to survive the
-    /// string round-trip into `UserOrgRole`, which is what the user-management
-    /// endpoints actually parse.
+    /// The wire spelling ("viewer") must survive the round-trip into
+    /// `UserOrgRole`, which is what the user-management endpoints parse.
     #[cfg(not(feature = "enterprise"))]
     #[test]
     fn test_viewer_role_request_parses_in_oss() {
@@ -580,8 +561,7 @@ mod tests {
         assert_eq!(parsed.base_role, UserRole::Viewer);
         assert!(parsed.custom_role.is_none());
 
-        // A role OSS cannot enforce falls back to the default (Admin) and is
-        // carried along as a custom role, which OSS then rejects outright.
+        // An unenforceable role falls back to Admin, carried as a custom role.
         let parsed = UserOrgRole::from(&UserRoleRequest {
             role: "editor".to_string(),
             custom: None,
@@ -956,9 +936,6 @@ mod tests {
         // Non-enterprise mode should have specific roles
         #[cfg(not(feature = "enterprise"))]
         {
-            // Viewer is included because OSS enforces read-only accounts itself
-            // (see `super::read_only_routes`); the remaining fine-grained roles
-            // need an authorization model OSS does not have.
             assert_eq!(roles.len(), 4);
             assert!(roles.contains(&UserRole::Admin));
             assert!(roles.contains(&UserRole::Root));

--- a/src/common/src/meta/user.rs
+++ b/src/common/src/meta/user.rs
@@ -174,9 +174,41 @@ pub fn get_roles() -> Vec<UserRole> {
     UserRole::iter().collect()
 }
 
+/// Roles an OSS deployment understands.
+///
+/// OSS has no OpenFGA, so the fine-grained roles (`Editor`, `User`, custom
+/// roles) are not offered — there is nothing to enforce them with. `Viewer` is
+/// the exception: it is a whole-org "read only" account, which the auth layer
+/// enforces on its own via the read-only route policy, so it is available in
+/// OSS as well.
 #[cfg(not(feature = "enterprise"))]
 pub fn get_roles() -> Vec<UserRole> {
-    vec![UserRole::Admin, UserRole::Root, UserRole::ServiceAccount]
+    vec![
+        UserRole::Admin,
+        UserRole::Root,
+        UserRole::ServiceAccount,
+        UserRole::Viewer,
+    ]
+}
+
+/// Collapse a *requested* role to what an OSS deployment can actually enforce.
+///
+/// This is the single rule behind every OSS role assignment. `Viewer` is
+/// honoured — the auth layer enforces it by itself through the read-only route
+/// policy — and everything else collapses to `Admin`, which is the
+/// long-standing OSS behaviour for roles it has no enforcement for.
+///
+/// Note what this deliberately does *not* do: it never elevates. A request
+/// asking for `Root` gets `Admin`, so the user-management endpoints cannot be
+/// used to mint a privileged account. Service accounts are unaffected because
+/// they are created through their own endpoint, which sets the role directly.
+#[cfg(not(feature = "enterprise"))]
+pub fn get_supported_role(requested: &UserRole) -> UserRole {
+    if requested == &UserRole::Viewer {
+        UserRole::Viewer
+    } else {
+        UserRole::Admin
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
@@ -480,6 +512,58 @@ mod tests {
     use std::collections::HashSet;
 
     use super::*;
+
+    /// The read-only Viewer is assignable in OSS; the fine-grained roles, which
+    /// OSS has no enforcement for, are not offered.
+    #[cfg(not(feature = "enterprise"))]
+    #[test]
+    fn test_oss_roles_include_viewer() {
+        let roles = get_roles();
+        assert!(roles.contains(&UserRole::Viewer));
+        assert!(roles.contains(&UserRole::Admin));
+        assert!(!roles.contains(&UserRole::Editor));
+        assert!(!roles.contains(&UserRole::User));
+    }
+
+    /// A role request resolves to Viewer or Admin and nothing else — in
+    /// particular a request for Root must not elevate.
+    #[cfg(not(feature = "enterprise"))]
+    #[test]
+    fn test_get_supported_role() {
+        assert_eq!(get_supported_role(&UserRole::Viewer), UserRole::Viewer);
+        for role in [
+            UserRole::Admin,
+            UserRole::Editor,
+            UserRole::User,
+            UserRole::Root,
+            UserRole::ServiceAccount,
+            UserRole::SreAgent,
+        ] {
+            assert_eq!(get_supported_role(&role), UserRole::Admin);
+        }
+    }
+
+    /// The role a client asks for on the wire ("viewer") has to survive the
+    /// string round-trip into `UserOrgRole`, which is what the user-management
+    /// endpoints actually parse.
+    #[cfg(not(feature = "enterprise"))]
+    #[test]
+    fn test_viewer_role_request_parses_in_oss() {
+        let parsed = UserOrgRole::from(&UserRoleRequest {
+            role: "viewer".to_string(),
+            custom: None,
+        });
+        assert_eq!(parsed.base_role, UserRole::Viewer);
+        assert!(parsed.custom_role.is_none());
+
+        // A role OSS cannot enforce falls back to the default (Admin) and is
+        // carried along as a custom role, which OSS then rejects outright.
+        let parsed = UserOrgRole::from(&UserRoleRequest {
+            role: "editor".to_string(),
+            custom: None,
+        });
+        assert_eq!(parsed.base_role, UserRole::Admin);
+    }
 
     #[test]
     fn test_user_request() {

--- a/src/common/src/meta/user.rs
+++ b/src/common/src/meta/user.rs
@@ -525,6 +525,30 @@ mod tests {
         assert!(!roles.contains(&UserRole::User));
     }
 
+    /// `get_roles` (what OSS knows about) and `get_supported_role` (what OSS
+    /// will actually assign) must not drift apart, or a role reachable through
+    /// the API gets silently rewritten on save. Every listed role has to fall
+    /// into one of the two groups below, so adding one forces that decision.
+    #[cfg(not(feature = "enterprise"))]
+    #[test]
+    fn test_offered_roles_are_assignable() {
+        // Assignable through the users API, and preserved as asked.
+        for role in [UserRole::Admin, UserRole::Viewer] {
+            assert_eq!(
+                get_supported_role(&role),
+                role,
+                "OSS offers {role} but would assign something else"
+            );
+        }
+        // Listed so existing accounts resolve, but never assignable through the
+        // users API: Root must not be mintable, and a service account gets its
+        // role from the service-account endpoints, not this path.
+        for role in [UserRole::Root, UserRole::ServiceAccount] {
+            assert_eq!(get_supported_role(&role), UserRole::Admin);
+        }
+        assert_eq!(get_roles().len(), 4, "a new OSS role needs a group above");
+    }
+
     /// A role request resolves to Viewer or Admin and nothing else — in
     /// particular a request for Root must not elevate.
     #[cfg(not(feature = "enterprise"))]
@@ -932,10 +956,14 @@ mod tests {
         // Non-enterprise mode should have specific roles
         #[cfg(not(feature = "enterprise"))]
         {
-            assert_eq!(roles.len(), 3);
+            // Viewer is included because OSS enforces read-only accounts itself
+            // (see `super::read_only_routes`); the remaining fine-grained roles
+            // need an authorization model OSS does not have.
+            assert_eq!(roles.len(), 4);
             assert!(roles.contains(&UserRole::Admin));
             assert!(roles.contains(&UserRole::Root));
             assert!(roles.contains(&UserRole::ServiceAccount));
+            assert!(roles.contains(&UserRole::Viewer));
         }
 
         // Enterprise mode uses iterator over all roles

--- a/src/common/src/utils/grpc_auth.rs
+++ b/src/common/src/utils/grpc_auth.rs
@@ -1,0 +1,119 @@
+// Copyright 2026 OpenObserve Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Binding a gRPC request to the organization its caller authenticated for.
+//!
+//! SECURITY (GHSA-5x2v-jg9q-g8qc): a handler must not trust an `org_id` taken
+//! from the request body. The auth interceptor checks membership only against
+//! the organization *header*, so a user credential for org A can carry a body
+//! naming org B and read another tenant's data.
+
+use tonic::{Request, Status};
+
+/// The organization this caller authenticated for, or `None` if the caller is
+/// not a user.
+///
+/// The auth interceptor appends `user_id` metadata only for user-credential
+/// callers — internal-token callers (intra-cluster and super-cluster RPCs)
+/// leave it absent, and those legitimately address any org. A `Some` must
+/// replace whatever the body said; see [`bind_org`].
+pub fn authenticated_org<T>(request: &Request<T>) -> Result<Option<String>, Status> {
+    let cfg = config::get_config();
+    authenticated_org_with(request, &cfg.grpc.org_header_key)
+}
+
+/// [`authenticated_org`] with the header key supplied, so the rule itself can
+/// be tested without a loaded config.
+fn authenticated_org_with<T>(
+    request: &Request<T>,
+    org_header_key: &str,
+) -> Result<Option<String>, Status> {
+    let metadata = request.metadata();
+    if metadata.get("user_id").is_none() {
+        return Ok(None);
+    }
+    metadata
+        .get(org_header_key)
+        .and_then(|v| v.to_str().ok())
+        .map(|org| Some(org.to_string()))
+        .ok_or_else(|| {
+            Status::unauthenticated("missing organization header for user-authenticated request")
+        })
+}
+
+/// Overwrite `org_id` with the caller's authenticated org, for user callers.
+///
+/// Take this before `into_inner()` consumes the metadata:
+///
+/// ```ignore
+/// let org = authenticated_org(&request)?;
+/// let mut req = request.into_inner();
+/// bind_org(&mut req.org_id, org);
+/// ```
+pub fn bind_org(org_id: &mut String, authenticated: Option<String>) {
+    if let Some(org) = authenticated {
+        *org_id = org;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request_with(metadata: &[(&'static str, &str)]) -> Request<()> {
+        let mut request = Request::new(());
+        for (key, value) in metadata {
+            request
+                .metadata_mut()
+                .insert(*key, value.parse().expect("valid metadata value"));
+        }
+        request
+    }
+
+    /// No `user_id` means an internal-token caller, which may address any org.
+    #[test]
+    fn internal_callers_are_not_rebound() {
+        let request = request_with(&[("organization", "other")]);
+        assert_eq!(
+            authenticated_org_with(&request, "organization").unwrap(),
+            None
+        );
+
+        let mut org = "other".to_string();
+        bind_org(&mut org, None);
+        assert_eq!(org, "other");
+    }
+
+    /// A user caller is pinned to the header org, whatever the body claimed.
+    #[test]
+    fn user_callers_are_rebound_to_their_header_org() {
+        let request = request_with(&[("user_id", "viewer@example.com"), ("organization", "mine")]);
+        let authenticated = authenticated_org_with(&request, "organization").unwrap();
+        assert_eq!(authenticated.as_deref(), Some("mine"));
+
+        let mut org = "victim".to_string();
+        bind_org(&mut org, authenticated);
+        assert_eq!(org, "mine");
+    }
+
+    /// Fail closed: a user caller without an org header is refused rather than
+    /// left on the body's value.
+    #[test]
+    fn a_user_caller_without_an_org_header_is_refused() {
+        let request = request_with(&[("user_id", "viewer@example.com")]);
+        let err = authenticated_org_with(&request, "organization").unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unauthenticated);
+    }
+}

--- a/src/common/src/utils/mod.rs
+++ b/src/common/src/utils/mod.rs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+pub mod grpc_auth;
 pub mod http;
 pub mod jwt;
 pub mod redirect_response;

--- a/src/config/src/meta/user.rs
+++ b/src/config/src/meta/user.rs
@@ -127,13 +127,8 @@ impl UserRole {
         matches!(self, UserRole::ServiceAccount | UserRole::SreAgent)
     }
 
-    /// Returns true for roles that may only *read*.
-    ///
-    /// `Viewer` is the human "read only" account; `SreAgent` is the
-    /// system-managed equivalent for agent tokens. In enterprise builds the
-    /// OpenFGA model is what actually enforces this; in OSS builds (no FGA) the
-    /// auth layer uses this flag together with the `read_only_routes` policy
-    /// table (in the `common` crate) to reject writes.
+    /// Roles that may only read. Enforced by OpenFGA in enterprise builds, and
+    /// by the `read_only_routes` policy table in OSS builds.
     pub fn is_read_only(&self) -> bool {
         matches!(self, UserRole::Viewer | UserRole::SreAgent)
     }
@@ -456,8 +451,7 @@ mod tests {
         assert!(!UserRole::Admin.is_read_only());
         assert!(!UserRole::Editor.is_read_only());
         assert!(!UserRole::ServiceAccount.is_read_only());
-        // `User` is a login-only account with no access at all — it is not a
-        // read-only account, and must not be granted read access by proxy.
+        // `User` is login-only with no access, not a read-only account.
         assert!(!UserRole::User.is_read_only());
     }
 

--- a/src/config/src/meta/user.rs
+++ b/src/config/src/meta/user.rs
@@ -127,6 +127,17 @@ impl UserRole {
         matches!(self, UserRole::ServiceAccount | UserRole::SreAgent)
     }
 
+    /// Returns true for roles that may only *read*.
+    ///
+    /// `Viewer` is the human "read only" account; `SreAgent` is the
+    /// system-managed equivalent for agent tokens. In enterprise builds the
+    /// OpenFGA model is what actually enforces this; in OSS builds (no FGA) the
+    /// auth layer uses this flag together with the `read_only_routes` policy
+    /// table (in the `common` crate) to reject writes.
+    pub fn is_read_only(&self) -> bool {
+        matches!(self, UserRole::Viewer | UserRole::SreAgent)
+    }
+
     pub fn get_label(&self) -> String {
         match self {
             UserRole::Admin => "Admin".to_string(),
@@ -435,6 +446,19 @@ mod tests {
         assert!(!UserRole::Admin.is_service_account());
         assert!(!UserRole::Viewer.is_service_account());
         assert!(!UserRole::Root.is_service_account());
+    }
+
+    #[test]
+    fn test_user_role_is_read_only() {
+        assert!(UserRole::Viewer.is_read_only());
+        assert!(UserRole::SreAgent.is_read_only());
+        assert!(!UserRole::Root.is_read_only());
+        assert!(!UserRole::Admin.is_read_only());
+        assert!(!UserRole::Editor.is_read_only());
+        assert!(!UserRole::ServiceAccount.is_read_only());
+        // `User` is a login-only account with no access at all — it is not a
+        // read-only account, and must not be granted read access by proxy.
+        assert!(!UserRole::User.is_read_only());
     }
 
     #[test]

--- a/src/core/src/auth.rs
+++ b/src/core/src/auth.rs
@@ -163,9 +163,8 @@ pub fn get_role(role: &UserOrgRole) -> UserRole {
     UserRole::from_str(&role).unwrap()
 }
 
-/// Resolve the effective base role for an OSS deployment: the read-only
-/// `Viewer` is honoured, everything else collapses to `Admin`. See
-/// [`common::meta::user::get_supported_role`] for why.
+/// Effective base role in OSS: `Viewer` is honoured, everything else collapses
+/// to `Admin`. See [`common::meta::user::get_supported_role`].
 #[cfg(not(feature = "enterprise"))]
 pub fn get_role(role: &UserOrgRole) -> UserRole {
     common::meta::user::get_supported_role(&role.base_role)
@@ -971,8 +970,7 @@ mod tests {
     #[cfg(not(feature = "enterprise"))]
     #[test]
     fn test_get_role_non_enterprise() {
-        // Roles OSS cannot enforce collapse to Admin — including Root, so this
-        // path can never be used to elevate a user.
+        // Unenforceable roles collapse to Admin, including Root — no elevation.
         for role in [
             UserRole::User,
             UserRole::Editor,
@@ -986,7 +984,6 @@ mod tests {
             assert_eq!(get_role(&user_role), UserRole::Admin);
         }
 
-        // The read-only Viewer is the one non-admin role OSS honours.
         let user_role = UserOrgRole {
             base_role: UserRole::Viewer,
             custom_role: None,

--- a/src/core/src/auth.rs
+++ b/src/core/src/auth.rs
@@ -163,9 +163,12 @@ pub fn get_role(role: &UserOrgRole) -> UserRole {
     UserRole::from_str(&role).unwrap()
 }
 
+/// Resolve the effective base role for an OSS deployment: the read-only
+/// `Viewer` is honoured, everything else collapses to `Admin`. See
+/// [`common::meta::user::get_supported_role`] for why.
 #[cfg(not(feature = "enterprise"))]
-pub fn get_role(_role: &UserOrgRole) -> UserRole {
-    UserRole::Admin
+pub fn get_role(role: &UserOrgRole) -> UserRole {
+    common::meta::user::get_supported_role(&role.base_role)
 }
 
 fn deserialize_trimmed<'de, D>(deserializer: D) -> Result<String, D::Error>
@@ -968,13 +971,27 @@ mod tests {
     #[cfg(not(feature = "enterprise"))]
     #[test]
     fn test_get_role_non_enterprise() {
+        // Roles OSS cannot enforce collapse to Admin — including Root, so this
+        // path can never be used to elevate a user.
+        for role in [
+            UserRole::User,
+            UserRole::Editor,
+            UserRole::Root,
+            UserRole::ServiceAccount,
+        ] {
+            let user_role = UserOrgRole {
+                base_role: role,
+                custom_role: None,
+            };
+            assert_eq!(get_role(&user_role), UserRole::Admin);
+        }
+
+        // The read-only Viewer is the one non-admin role OSS honours.
         let user_role = UserOrgRole {
-            base_role: UserRole::User,
+            base_role: UserRole::Viewer,
             custom_role: None,
         };
-
-        // In non-enterprise mode, should always return Admin
-        assert_eq!(get_role(&user_role), UserRole::Admin);
+        assert_eq!(get_role(&user_role), UserRole::Viewer);
     }
 
     #[cfg(not(feature = "enterprise"))]

--- a/src/core/src/users.rs
+++ b/src/core/src/users.rs
@@ -264,6 +264,10 @@ pub async fn update_user(
     mut user: UpdateUser,
 ) -> Result<Response, Error> {
     let mut allow_password_update = false;
+    // Whether the initiator may administer `email` — i.e. change a role that is
+    // not their own. Computed alongside `allow_password_update` below, which
+    // covers only passwords and tokens and so left role changes unguarded.
+    let mut allow_role_update = false;
     #[cfg(feature = "cloud")]
     let is_cloud = true;
     #[cfg(not(feature = "cloud"))]
@@ -328,7 +332,8 @@ pub async fn update_user(
                 }
                 if !update_mode.is_self_update() {
                     if is_root_user(initiator_id) {
-                        allow_password_update = true
+                        allow_password_update = true;
+                        allow_role_update = true;
                     } else {
                         let initiating_user = match db::user::get(Some(org_id), initiator_id).await
                         {
@@ -347,7 +352,8 @@ pub async fn update_user(
                                 && (initiating_user.role.eq(&UserRole::Admin)
                                     || initiating_user.role.eq(&UserRole::Root)))
                         {
-                            allow_password_update = true
+                            allow_password_update = true;
+                            allow_role_update = true;
                         }
                     }
                 }
@@ -425,6 +431,17 @@ pub async fn update_user(
                         message = "Root user role cannot be changed";
                     } else if update_mode.is_self_update() && local_user.role < new_user.role {
                         message = "Self role cannot be upgraded";
+                    } else if !update_mode.is_self_update()
+                        && !allow_role_update
+                        && local_user.role.ne(&new_user.role)
+                    {
+                        // Changing somebody else's role is privileged. Without
+                        // this, the only thing standing between an unprivileged
+                        // caller and an arbitrary role change was the
+                        // `is_self_update` branch above — so anything that made
+                        // a self-update look like an update of *another* account
+                        // skipped the check entirely rather than tightening it.
+                        message = "Only Admin or Root can change a user's role";
                     } else {
                         is_org_updated |= local_user.role.ne(&new_user.role);
                         #[cfg(feature = "enterprise")]
@@ -1335,6 +1352,7 @@ pub async fn create_service_account_if_not_exists(email: &str) -> Result<(), any
 
 #[cfg(test)]
 mod tests {
+    use axum::http::StatusCode;
     use common::{infra::config::USERS, meta::user::get_default_user_role};
     use config::meta::user::{UserRole, UserType};
     use infra::{
@@ -1474,6 +1492,92 @@ mod tests {
                 password_ext: Some("root_password_ext_hash".to_string()),
             },
         );
+    }
+
+    /// A read-only account must not be able to hand itself a role it does not
+    /// have. The `is_self_update` guard alone was not enough: anything that made
+    /// a self-update look like an update of *another* account — a path email
+    /// differing only in letter case, since every lookup below resolves
+    /// case-insensitively — skipped that guard instead of tightening it. The
+    /// role branch now demands an Admin/Root initiator in its own right.
+    #[tokio::test]
+    async fn test_unprivileged_initiator_cannot_change_a_role() {
+        set_up().await;
+
+        post_user(
+            "dummy",
+            UserRequest {
+                email: "viewer@zo.dev".to_string(),
+                password: "pass#123".to_string(),
+                role: common::meta::user::UserOrgRole {
+                    base_role: UserRole::Viewer,
+                    custom_role: None,
+                },
+                first_name: "viewer".to_owned(),
+                last_name: "".to_owned(),
+                is_external: false,
+                token: None,
+            },
+            "admin@zo.dev",
+        )
+        .await
+        .expect("failed to create the viewer");
+
+        let promote_to_admin = || UpdateUser {
+            role: Some(common::meta::user::UserRoleRequest {
+                role: UserRole::Admin.to_string(),
+                custom: None,
+            }),
+            token: None,
+            first_name: None,
+            last_name: None,
+            old_password: None,
+            new_password: None,
+            change_password: false,
+        };
+
+        // Read the stored role, not `get_user` — that reads the ORG_USERS cache,
+        // which only the coordinator watcher refreshes and which therefore never
+        // moves in a unit test. Asserting the cache would pass whether or not
+        // the write was actually refused.
+        let stored_role = async || {
+            db::org_users::get_from_db("dummy", "viewer@zo.dev")
+                .await
+                .unwrap()
+                .role
+        };
+
+        // The escalation path: a Viewer naming itself, but in a spelling that
+        // does not compare equal to its canonical email, so the caller is
+        // treated as updating somebody else.
+        let resp = update_user(
+            "dummy",
+            "viewer@zo.dev",
+            UserUpdateMode::OtherUpdate,
+            "viewer@zo.dev",
+            promote_to_admin(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            stored_role().await,
+            UserRole::Viewer,
+            "role must be unchanged after a refused escalation"
+        );
+
+        // The same request from an Admin is legitimate and still works.
+        let resp = update_user(
+            "dummy",
+            "viewer@zo.dev",
+            UserUpdateMode::OtherUpdate,
+            "admin@zo.dev",
+            promote_to_admin(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(stored_role().await, UserRole::Admin);
     }
 
     #[tokio::test]

--- a/src/core/src/users.rs
+++ b/src/core/src/users.rs
@@ -267,6 +267,13 @@ pub async fn update_user(
     // May the initiator change a role that is not their own? The neighbouring
     // `allow_password_update` covers only passwords and tokens.
     let mut allow_role_update = false;
+    // Only enforce `allow_role_update` where nothing else authorizes the change.
+    // With OpenFGA on, a delegated role manager has already passed the
+    // permission middleware and need not be an Admin.
+    #[cfg(not(feature = "enterprise"))]
+    let enforce_role_update = true;
+    #[cfg(feature = "enterprise")]
+    let enforce_role_update = !get_openfga_config().enabled;
     #[cfg(feature = "cloud")]
     let is_cloud = true;
     #[cfg(not(feature = "cloud"))]
@@ -430,7 +437,8 @@ pub async fn update_user(
                         message = "Root user role cannot be changed";
                     } else if update_mode.is_self_update() && local_user.role < new_user.role {
                         message = "Self role cannot be upgraded";
-                    } else if !update_mode.is_self_update()
+                    } else if enforce_role_update
+                        && !update_mode.is_self_update()
                         && !allow_role_update
                         && local_user.role.ne(&new_user.role)
                     {

--- a/src/core/src/users.rs
+++ b/src/core/src/users.rs
@@ -264,9 +264,8 @@ pub async fn update_user(
     mut user: UpdateUser,
 ) -> Result<Response, Error> {
     let mut allow_password_update = false;
-    // Whether the initiator may administer `email` — i.e. change a role that is
-    // not their own. Computed alongside `allow_password_update` below, which
-    // covers only passwords and tokens and so left role changes unguarded.
+    // May the initiator change a role that is not their own? The neighbouring
+    // `allow_password_update` covers only passwords and tokens.
     let mut allow_role_update = false;
     #[cfg(feature = "cloud")]
     let is_cloud = true;
@@ -435,12 +434,9 @@ pub async fn update_user(
                         && !allow_role_update
                         && local_user.role.ne(&new_user.role)
                     {
-                        // Changing somebody else's role is privileged. Without
-                        // this, the only thing standing between an unprivileged
-                        // caller and an arbitrary role change was the
-                        // `is_self_update` branch above — so anything that made
-                        // a self-update look like an update of *another* account
-                        // skipped the check entirely rather than tightening it.
+                        // Without this, anything that made a self-update look
+                        // like an update of another account skipped the
+                        // `is_self_update` guard instead of tightening it.
                         message = "Only Admin or Root can change a user's role";
                     } else {
                         is_org_updated |= local_user.role.ne(&new_user.role);
@@ -1494,12 +1490,9 @@ mod tests {
         );
     }
 
-    /// A read-only account must not be able to hand itself a role it does not
-    /// have. The `is_self_update` guard alone was not enough: anything that made
-    /// a self-update look like an update of *another* account — a path email
-    /// differing only in letter case, since every lookup below resolves
-    /// case-insensitively — skipped that guard instead of tightening it. The
-    /// role branch now demands an Admin/Root initiator in its own right.
+    /// A read-only account must not hand itself a role. The `is_self_update`
+    /// guard alone was not enough, so the role branch now demands an Admin/Root
+    /// initiator in its own right.
     #[tokio::test]
     async fn test_unprivileged_initiator_cannot_change_a_role() {
         set_up().await;
@@ -1537,9 +1530,7 @@ mod tests {
         };
 
         // Read the stored role, not `get_user` — that reads the ORG_USERS cache,
-        // which only the coordinator watcher refreshes and which therefore never
-        // moves in a unit test. Asserting the cache would pass whether or not
-        // the write was actually refused.
+        // which no watcher refreshes under test, so it would pass either way.
         let stored_role = async || {
             db::org_users::get_from_db("dummy", "viewer@zo.dev")
                 .await
@@ -1547,9 +1538,8 @@ mod tests {
                 .role
         };
 
-        // The escalation path: a Viewer naming itself, but in a spelling that
-        // does not compare equal to its canonical email, so the caller is
-        // treated as updating somebody else.
+        // A Viewer naming itself in a spelling that does not compare equal to
+        // its canonical email, so it reads as updating somebody else.
         let resp = update_user(
             "dummy",
             "viewer@zo.dev",
@@ -1566,7 +1556,7 @@ mod tests {
             "role must be unchanged after a refused escalation"
         );
 
-        // The same request from an Admin is legitimate and still works.
+        // The same request from an Admin still works.
         let resp = update_user(
             "dummy",
             "viewer@zo.dev",

--- a/src/search_service/src/grpc_server.rs
+++ b/src/search_service/src/grpc_server.rs
@@ -13,7 +13,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use common::meta::grpc::MetadataMap;
+use common::{
+    meta::grpc::MetadataMap,
+    utils::grpc_auth::{authenticated_org, bind_org},
+};
 use config::{
     meta::{search, stream::StreamType},
     utils::json,
@@ -55,7 +58,9 @@ impl Search for Searcher {
         let _ = tracing::Span::current().set_parent(parent_cx.clone());
 
         let start = std::time::Instant::now();
-        let req = req.into_inner();
+        let authenticated_org = authenticated_org(&req)?;
+        let mut req = req.into_inner();
+        bind_org(&mut req.org_id, authenticated_org);
         let request = json::from_slice::<search::Request>(&req.request)
             .map_err(|e| Status::internal(format!("failed to parse search request: {e}")))?;
         let stream_type = StreamType::from(req.stream_type.as_str());
@@ -97,7 +102,9 @@ impl Search for Searcher {
         });
         let _ = tracing::Span::current().set_parent(parent_cx.clone());
 
-        let req = req.into_inner();
+        let authenticated_org = authenticated_org(&req)?;
+        let mut req = req.into_inner();
+        bind_org(&mut req.org_id, authenticated_org);
         let request =
             json::from_slice::<search::MultiStreamRequest>(&req.request).map_err(|e| {
                 Status::internal(format!("failed to parse multi-stream search request: {e}"))
@@ -125,7 +132,9 @@ impl Search for Searcher {
         &self,
         req: Request<SearchPartitionRequest>,
     ) -> Result<Response<SearchPartitionResponse>, Status> {
-        let req = req.into_inner();
+        let authenticated_org = authenticated_org(&req)?;
+        let mut req = req.into_inner();
+        bind_org(&mut req.org_id, authenticated_org);
         let request =
             json::from_slice::<search::SearchPartitionRequest>(&req.request).map_err(|e| {
                 Status::internal(format!("failed to parse search partition request: {e}"))
@@ -428,7 +437,9 @@ impl Search for Searcher {
         &self,
         req: Request<GetWorkflowInputsRequest>,
     ) -> Result<Response<GetWorkflowInputsResponse>, Status> {
-        let req = req.into_inner();
+        let authenticated_org = authenticated_org(&req)?;
+        let mut req = req.into_inner();
+        bind_org(&mut req.org_id, authenticated_org);
 
         let org_id = req.org_id;
         let w_id = req.workflow_id;


### PR DESCRIPTION
Makes `Viewer` a usable role in OSS builds: an account that can read everything in its org and write nothing.

## Why this needs new machinery

In enterprise builds every route carries a declared permission and OpenFGA decides. OSS has no FGA, so once a request authenticates there is nothing left to distinguish a `Viewer` from an `Admin` — which is why OSS previously collapsed every requested role to `Admin` rather than pretend to offer roles it could not enforce. Honouring `Viewer` therefore means OSS has to enforce it directly, in the auth layer.

## What a read-only account may do

A single declarative policy — `common::meta::read_only_routes` — answers this for every authenticated request:

1. **Safe methods** (`GET`, `HEAD`, `OPTIONS`) pass, except for the routes in `SAFE_METHOD_EXCEPTIONS`.
2. **Query-by-POST routes** pass, from an explicit table: search, PromQL's POST forms, alert export, stacktrace symbolication. Each row reads and persists nothing; it uses a write method only because the query travels in the body.
3. **Self-service** passes — the caller's own profile/password and own per-user UI settings.

Everything else, ingestion included, is refused with `403`.

`GET` is only *presumed* harmless, and two kinds of route break the presumption. `GET /{org}/passcode` returns the org-wide ingestion token unmasked — and that token authenticates with no role at all, so a Viewer holding it could ingest freely with the gate never seeing the write. `/node/reload`, `/node/refresh_nodes_list` and `/node/refresh_user_sessions` rebuild caches behind a `GET` with no role check of their own. Both kinds are refused ahead of the safe-method allowance.

## Where it is enforced

- **HTTP** — in `validate_credentials`, on the *resolved* response rather than at each of the inner function's several success exits (service-account token, ingestion token, password), so a credential branch added later cannot silently open a write path. The RUM token bypasses that function entirely and is checked separately.
- **gRPC** — in `check_auth_inner`, keyed on the service's declared `is_write`. Keying on `allow_org_ingestion_token` instead would have left the internal ingest service uncovered.

The gate sits in the auth layer, not the permission layer, because OSS sets `bypass_check` on every request — the permission layer never runs.

## Things worth a reviewer's attention

**Authentication strictly precedes authorization.** A wrong password on a write service must answer `unauthenticated`, never `permission_denied`; the latter tells an unauthenticated caller that the account exists *and* is read only. Covered by a test.

**Role changes no longer trust `update_mode` alone.** Making `Viewer` assignable exposed a pre-existing hole: `update_user` refused a role upgrade only on its `is_self_update` branch, so anything that made a self-update *look* like an update of another account skipped the check rather than tightening it. `PUT /{org}/users/Viewer@example.com` did exactly that — the read-only gate matches the caller's email case-insensitively (correctly, since every lookup underneath does), while the handler compared byte-for-byte against the canonical lowercase form. A Viewer could hand itself Admin, and get a `200`. Fixed at both layers: the handler lowercases the path segment, and changing a role that is not your own now requires an Admin/Root initiator — enforced only where OpenFGA is not already authorizing the change, so enterprise's delegated role managers are unaffected.

**gRPC reads are now bound to the authenticated organization.** The interceptor resolves membership from the `organization` header while the handlers read `org_id` out of the request body, so a credential for org A could name org B and read another tenant's data. This is GHSA-5x2v-jg9q-g8qc, fixed at the time for `stream_stats` only and never swept across the rest. It predates read-only accounts and affects every role, but it is fixed here because it is what makes a Viewer's read privileges mean anything. `common::utils::grpc_auth` now holds the rule; `search`, `search_multi`, `search_partition`, `get_workflow_inputs`, the metrics `query`/`data` RPCs and `ingest` are rebound. Internal-token callers are untouched, since the interceptor returns before appending the `user_id` metadata the helper keys on.

Two gRPC services also moved to the write-only interceptor: `QueryCache`, whose only RPC is `DeleteResultCache`, and `Event`, which carries `SendFileList`.

## Route matching

`read_only_routes` and the existing `ingestion_routes` now share one positional matcher (`common::meta::route_match`) instead of keeping two copies of the same normalisation rules. Positional rather than substring matching: substring matching is what let an ingestion token read `GET /{org}/{stream}/traces/latest` (GHSA-wffq-g8qf-ccmv). A stream *named* `traces` only ever lands in a parameter slot.

`/v2/_search` is genuinely ambiguous — the versioned API prefix, or an org literally named `v2`, which nothing reserves — so both readings are offered and a row matches if either does.

## Tests

New coverage for the route table (including the percent-encoded-email case the frontend actually sends, the credential and cache-mutating GETs, and the `v2` org), the org rebinding, the role conjunction, OSS role resolution, the gRPC read/write split, the authenticate-before-authorize ordering, and the escalation itself. The escalation, credential, cache-mutation and `v2` tests were each confirmed to fail without their fix.

Suites run green locally: `common` 18/18, `openobserve-core` 42/42, `openobserve-api-management` 8/8, `openobserve-api-grpc` 8/8.

## Known adjacent issues, deliberately not fixed here

- `get_sourcemap_file` keys storage off a caller-supplied `req.path` and only logs `org_id`, so org rebinding does nothing for it. Constraining that path wants its own change.
- `ingestion_routes` keeps its single-reading `v2` normalisation. The same false negative exists there, but widening what counts as an ingestion path is a security question of its own.
- `allow_password_update` is computed from the same Admin/Root test as the role guard, so delegated FGA managers likely hit that wall too. Predates this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bhg7r5KoFPAPrNNBUDNwdY